### PR TITLE
Fix Uncategorized section visibility in shop mode

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1359,9 +1359,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             const totalItemsInSection = sectionItems.length;
 
             if (!isHome && section.id === shopDefId) {
-                // In shop mode, Uncategorized is only visible if at least one item is needed
-                const hasNeededItems = sectionItems.some(item => (item.wantCount - item.haveCount) > 0);
-                if (!hasNeededItems) {
+                // In shop mode, Uncategorized is only visible if at least one item is in the section
+                if (totalItemsInSection === 0) {
                     return; // Skip rendering Uncategorized
                 }
             }


### PR DESCRIPTION
Fixes a bug where the "Uncategorized" section is hidden in shop mode if every item has 0 quantity.

The expected behavior for the "Uncategorized" section is that it should only be hidden if there are 0 items in it.

---
*PR created automatically by Jules for task [10739920176367982382](https://jules.google.com/task/10739920176367982382) started by @camyoung1234*