### PR TITLE
Update Mode Switch Animation and Scroll to Top

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -275,14 +275,18 @@ document.addEventListener('DOMContentLoaded', async () => {
             return;
         }
 
-        // Material 3 Expressive Fade-through: out → switch → in
-        const fadeOutClass = 'm3-fade-out';
-        const fadeInClass = 'm3-fade-in';
+        // Mode fade transition: out → scroll & switch → in
+        const fadeOutClass = 'mode-fade-out';
+        const fadeInClass = 'mode-fade-in';
 
         groceryList.classList.add(fadeOutClass);
         groceryList.addEventListener('animationend', function onOut() {
             groceryList.removeEventListener('animationend', onOut);
             groceryList.classList.remove(fadeOutClass);
+
+            // Scroll to top when current content is faded out
+            window.scrollTo(0, 0);
+            if (appContainer) appContainer.scrollTop = 0;
 
             doSwitch();
 
@@ -290,7 +294,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             groceryList.addEventListener('animationend', function onIn() {
                 groceryList.removeEventListener('animationend', onIn);
                 groceryList.classList.remove(fadeInClass);
-            });
+            }, { once: true });
         }, { once: true });
     }
 

--- a/public/style.css
+++ b/public/style.css
@@ -476,7 +476,7 @@ h1 {
    and an incoming element fading in (0% -> 100%) and slightly scaling in (92% -> 100%).
    Timing: Exit 90ms, Enter 210ms. Total 300ms. */
 
-@keyframes m3FadeOut {
+@keyframes modeFadeOut {
     from {
         opacity: 1;
     }
@@ -486,26 +486,24 @@ h1 {
     }
 }
 
-@keyframes m3FadeIn {
+@keyframes modeFadeIn {
     from {
         opacity: 0;
-        transform: scale(0.92);
     }
 
     to {
         opacity: 1;
-        transform: scale(1);
     }
 }
 
 /* Outgoing animation */
-.m3-fade-out {
-    animation: m3FadeOut 90ms cubic-bezier(0.4, 0, 1, 1) forwards;
+.mode-fade-out {
+    animation: modeFadeOut 150ms ease-out forwards;
 }
 
 /* Incoming animation */
-.m3-fade-in {
-    animation: m3FadeIn 210ms cubic-bezier(0, 0, 0.2, 1) forwards;
+.mode-fade-in {
+    animation: modeFadeIn 150ms ease-in forwards;
 }
 
 .grocery-list.slide-left {


### PR DESCRIPTION
The mode switch animation has been updated to provide a smoother transition between "Home" and "Store" modes. 

Key changes:
- **Simplified Animations:** Replaced the previous Material 3 scale-and-fade transition with a pure opacity fade (`mode-fade-out` and `mode-fade-in`). Each phase now lasts 150ms for a total transition time of 300ms.
- **Scroll to Top:** When switching modes, the application now automatically scrolls both the window and the internal `.app-container` (used in desktop layouts) to the top. This happens while the content is faded out, ensuring the new mode is always viewed from the beginning of the list.
- **Robustness:** Fixed a class management issue where transition classes could persist, ensuring that subsequent mode switches trigger the animation correctly.

Verification was performed using a Playwright script that simulated multiple mode switches and confirmed that the scroll position reset to zero each time.

Fixes #33

---
*PR created automatically by Jules for task [13498697762883588603](https://jules.google.com/task/13498697762883588603) started by @camyoung1234*