### PR TITLE
Add Flare Animation for Store Mode Completion

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -823,22 +823,97 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (newInlineInput) newInlineInput.focus();
     }
 
-    function toggleShopCompleted(id) {
+    function createSparks(x, y) {
+        const count = 8;
+        const color = getComputedStyle(document.documentElement).getPropertyValue('--primary-color');
+
+        for (let i = 0; i < count; i++) {
+            const spark = document.createElement('div');
+            spark.className = 'spark-particle';
+            spark.style.backgroundColor = color;
+            spark.style.left = x + 'px';
+            spark.style.top = y + 'px';
+            
+            document.body.appendChild(spark);
+            
+            const angle = (i / count) * Math.PI * 2;
+            const velocity = 30 + Math.random() * 40;
+            const destinationX = Math.cos(angle) * velocity;
+            const destinationY = Math.sin(angle) * velocity;
+
+            spark.animate([
+                { transform: 'translate(-50%, -50%) scale(1)', opacity: 1 },
+                { transform: `translate(calc(-50% + ${destinationX}px), calc(-50% + ${destinationY}px)) scale(0)`, opacity: 0 }
+            ], {
+                duration: 600,
+                easing: 'cubic-bezier(0, .9, .57, 1)',
+                fill: 'forwards'
+            }).onfinish = () => spark.remove();
+        }
+    }
+
+    let isTogglingShop = false;
+    async function toggleShopCompleted(id) {
+        if (isTogglingShop) return;
         const currentList = getCurrentList();
         const item = currentList.items.find(i => i.id === id);
-        if (item) {
-            // Find all items with the same name to toggle them together (Grouping requirement)
-            const sameNameItems = currentList.items.filter(i => i.text === item.text);
-            const newState = !item.shopCompleted;
-            
-            sameNameItems.forEach(i => {
-                i.shopCompleted = newState;
-                i.shopCheckOrder = newState ? Date.now() : null;
-            });
-            
-            saveAppState();
-            renderList();
+        if (!item) return;
+
+        const sameNameItems = currentList.items.filter(i => i.text === item.text);
+        const newState = !item.shopCompleted;
+
+        // Find all DOM elements for grouped items
+        const elements = [];
+        sameNameItems.forEach(i => {
+            const el = document.querySelector(`.grocery-item[data-id="${i.id}"]`);
+            if (el) elements.push(el);
+        });
+
+        try {
+            isTogglingShop = true;
+            if (newState) {
+                // Completion sequence
+                elements.forEach(el => el.classList.add('is-completing'));
+
+                // Wait for strike-through + circle fill (0.4s + 0.3s)
+                await new Promise(r => setTimeout(r, 700));
+
+                // Trigger sparks
+                elements.forEach(el => {
+                    const circle = el.querySelector('.shop-qty-circle');
+                    if (circle) {
+                        const rect = circle.getBoundingClientRect();
+                        createSparks(rect.left + rect.width / 2, rect.top + rect.height / 2);
+                    }
+                });
+
+                // Wait for sparks to be visible
+                await new Promise(r => setTimeout(r, 100));
+
+                sameNameItems.forEach(i => {
+                    i.shopCompleted = true;
+                    i.shopCheckOrder = Date.now();
+                });
+            } else {
+                // Undo sequence
+                elements.forEach(el => {
+                    el.classList.remove('completed'); // Instantly remove completed state to trigger reverse transitions
+                    el.classList.add('is-undoing');
+                });
+
+                await new Promise(r => setTimeout(r, 300));
+
+                sameNameItems.forEach(i => {
+                    i.shopCompleted = false;
+                    i.shopCheckOrder = null;
+                });
+            }
+        } finally {
+            isTogglingShop = false;
         }
+
+        saveAppState();
+        renderList();
     }
 
     function deleteItem(id) {
@@ -1405,8 +1480,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                         } else {
                             // Normal behavior: toggle check off
                             toggleShopCompleted(item.id);
-                            item.shopCheckOrder = item.shopCompleted ? Date.now() : null;
-                            saveAppState();
                         }
                     });
 

--- a/public/style.css
+++ b/public/style.css
@@ -535,6 +535,100 @@ h1 {
     border-color: var(--primary-color);
 }
 
+/* Flare Animation Styles */
+.shop-chip .item-info::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 50%;
+    width: 0;
+    height: 2px;
+    background-color: var(--text-muted);
+    transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    z-index: 5;
+    pointer-events: none;
+}
+
+.shop-chip.is-completing .item-info::after,
+.shop-chip.completed .item-info::after {
+    width: calc(100% + 1rem);
+}
+
+.shop-chip.is-undoing .item-info::after {
+    width: 0;
+    transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+
+.shop-chip.is-undoing .shop-qty-circle::before {
+    width: 0 !important;
+    height: 0 !important;
+    transition: width 0.2s ease-in, height 0.2s ease-in !important;
+}
+
+.shop-chip.is-undoing .shop-qty-circle .qty-number {
+    transform: scale(1) translateY(0) !important;
+    opacity: 1 !important;
+    transition: all 0.2s ease-in !important;
+}
+
+.shop-chip.is-undoing .shop-qty-circle .check-icon {
+    transform: scale(0.5) translateY(10px) !important;
+    opacity: 0 !important;
+    transition: all 0.2s ease-in !important;
+}
+
+.shop-qty-circle::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 0;
+    height: 0;
+    background-color: var(--primary-color);
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1), height 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    z-index: -1;
+}
+
+.shop-chip.is-completing .shop-qty-circle::before {
+    width: 100%;
+    height: 100%;
+    transition-delay: 0.4s;
+}
+
+.shop-chip.completed .shop-qty-circle::before {
+    width: 100%;
+    height: 100%;
+}
+
+.shop-chip.is-completing .shop-qty-circle .qty-number {
+    transition-delay: 0.4s;
+    transform: scale(0.5) translateY(-10px);
+    opacity: 0;
+}
+
+.shop-chip.is-completing .shop-qty-circle .check-icon {
+    transition-delay: 0.4s;
+    transform: scale(1) translateY(0);
+    opacity: 1;
+}
+
+.spark-particle {
+    position: fixed;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: var(--primary-color);
+    pointer-events: none;
+    z-index: 10000;
+}
+
+/* Disable default strike-through for shop chips to use flare */
+.shop-chip.completed .item-text::after {
+    width: 0 !important;
+}
+
 .shop-qty-circle .qty-number,
 .shop-qty-circle .check-icon {
     position: absolute;


### PR DESCRIPTION
This change adds an exciting "flare" animation sequence when checking items off in Store Mode. 

Key improvements:
- **Visual Sequence:** When an item is checked, a strike-through animates across the row, followed by the quantity circle filling with color as the number transitions to a checkmark.
- **Spark Particles:** Once the circle is filled, spark particles shoot out from the center, providing satisfying visual feedback.
- **Reverse Animation:** Unchecking an item reverses the strike-through and circle transitions (without sparks).
- **Technical Implementation:** Uses an asynchronous sequence in `toggleShopCompleted` to coordinate CSS transitions with JavaScript-driven particles. Added an animation lock to prevent race conditions during the interaction.
- **Grouped Support:** All items with the same name animate simultaneously to maintain visual consistency across grouped views.

Fixes #38

---
*PR created automatically by Jules for task [4561356605378760714](https://jules.google.com/task/4561356605378760714) started by @camyoung1234*