### PR TITLE
Smooth transitions for Edit Mode toggle

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1919,6 +1919,7 @@ h1 {
 
 .hide-drag-handles .add-item-row,
 .hide-drag-handles .add-section-row {
+    height: 0;
     max-height: 0;
     opacity: 0;
     padding-top: 0;
@@ -2023,7 +2024,7 @@ h1 {
 /* Smooth shifting during drag */
 .grocery-item,
 .section-container {
-    transition: transform 0.2s ease, height 0.3s ease, opacity 0.3s ease;
+    transition: transform 0.2s ease, height 0.3s ease, max-height 0.3s ease, opacity 0.3s ease;
 }
 
 .no-transition, .no-transition * {


### PR DESCRIPTION
Fixed the jumping behavior when toggling edit mode. The "Add item" and "Add section" rows now grow and shrink their height smoothly over 0.3 seconds instead of appearing or disappearing instantly. This was achieved by:
1. Adding `height: 0` to the hidden state of these rows in `public/style.css`.
2. Ensuring `max-height` is included in the transition properties for list elements.
3. Verified the smooth animation using Playwright visual verification.

Fixes #52

---
*PR created automatically by Jules for task [15454210473472804088](https://jules.google.com/task/15454210473472804088) started by @camyoung1234*