### PR TITLE
Fix application loading error due to undefined variable

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1233,8 +1233,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             appContainer.classList.add('hide-drag-handles');
         } else {
             groceryList.classList.remove('shop-selection-mode');
-            // Only remove hide-drag-handles if showDragHandles is true
-            if (!showDragHandles) {
+            // Only remove hide-drag-handles if editMode is true
+            if (!editMode) {
                 appContainer.classList.add('hide-drag-handles');
             } else {
                 appContainer.classList.remove('hide-drag-handles');
@@ -1583,7 +1583,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
                     // Full-chip click toggle for Shop Mode
                     li.addEventListener('click', (e) => {
-                        if (shopSelectionMode || showDragHandles) {
+                        if (shopSelectionMode || editMode) {
                             // Selection Mode
                             if (selectedShopItems.has(item.id)) {
                                 selectedShopItems.delete(item.id);


### PR DESCRIPTION
The application was failing to render items due to a `ReferenceError: showDragHandles is not defined`. I identified two locations in `public/app.js` where this variable was used incorrectly. I replaced them with `editMode`, which is the variable used throughout the rest of the application to track whether the UI is in reorder/edit mode. I verified the fix using a Playwright script which confirmed that items are now rendered and no console errors are present.

Fixes #55

---
*PR created automatically by Jules for task [3664331629092890518](https://jules.google.com/task/3664331629092890518) started by @camyoung1234*