### PR TITLE
Update shop mode checkmark animation and strike-through color

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -515,10 +515,6 @@ h1 {
     }
 }
 
-.section-container .grocery-item.shop-chip:active {
-    transform: scale(0.95);
-}
-
 .section-container .grocery-item.shop-chip.completed {
     background: transparent;
 }
@@ -555,7 +551,7 @@ h1 {
     top: 50%;
     width: 0;
     height: 2px;
-    background-color: var(--text-muted);
+    background-color: var(--primary-color);
     transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     z-index: 5;
     pointer-events: none;


### PR DESCRIPTION
Updated the shop mode UI by removing the `transform: scale(0.95)` effect on active items and changing the strike-through `background-color` to use the theme's primary color. Verified the changes with Playwright screenshots.

Fixes #62

---
*PR created automatically by Jules for task [1686963236413412426](https://jules.google.com/task/1686963236413412426) started by @camyoung1234*