### PR TITLE
Fix theme flicker on page load

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,21 @@
     <meta name="apple-mobile-web-app-title" content="Groceries">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
+    <script>
+        (function() {
+            try {
+                const storedState = JSON.parse(localStorage.getItem('grocery-app-state'));
+                if (storedState && storedState.lists && storedState.currentListId) {
+                    const currentList = storedState.lists.find(l => l.id === storedState.currentListId);
+                    if (currentList && currentList.theme) {
+                        document.documentElement.style.setProperty('--primary-color', currentList.theme);
+                    }
+                }
+            } catch (e) {
+                console.warn('Failed to early-initialize theme:', e);
+            }
+        })();
+    </script>
 </head>
 
 <body>


### PR DESCRIPTION
The theme flicker issue was caused by the theme being applied in `app.js` after the `DOMContentLoaded` event, which occurs after the initial paint.

To fix this, I added a small, blocking inline script to the `<head>` of `index.html`. This script:
1. Reads `grocery-app-state` from `localStorage`.
2. Parses the state to find the `currentListId` and its associated `theme`.
3. Sets the `--primary-color` CSS variable on `document.documentElement`.

Since this script is in the `<head>`, it executes before the browser renders the `<body>`, ensuring the first drawn frame uses the correct theme colors.

Verification was performed using a Playwright script that measured the computed value of `--primary-color` at various stages of page load, confirming that it is now set to the user's theme from the very first measurement (as early as `readystatechange: interactive`).

Fixes #64

---
*PR created automatically by Jules for task [14818632407449595156](https://jules.google.com/task/14818632407449595156) started by @camyoung1234*