### PR TITLE
Fade store mode item text during strike-through

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -519,6 +519,19 @@ h1 {
     background: transparent;
 }
 
+.shop-chip .item-text {
+    transition: color 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.shop-chip.is-completing .item-text,
+.shop-chip.completed .item-text {
+    color: var(--text-muted) !important;
+}
+
+.shop-chip.is-undoing .item-text {
+    transition: color 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+
 .shop-qty-circle {
     display: flex;
     align-items: center;


### PR DESCRIPTION
This change enhances the visual feedback when marking items as completed in Store mode. Previously, only the strikethrough flare animated, while the text color changed abruptly or only after the animation finished. Now, the text color smoothly fades to `var(--text-muted)` over 0.4 seconds, perfectly synchronized with the strike-through flare. The undo transition is also smoothed out with a 0.3-second transition.

Modified `public/style.css`:
- Added `transition: color 0.4s cubic-bezier(0.4, 0, 0.2, 1)` to `.shop-chip .item-text`.
- Set `color: var(--text-muted) !important` for `.shop-chip.is-completing .item-text` and `.shop-chip.completed .item-text`.
- Added a specific 0.3s transition for the `.is-undoing` state.

Fixes #67

---
*PR created automatically by Jules for task [15929778666980178885](https://jules.google.com/task/15929778666980178885) started by @camyoung1234*