### PR TITLE
Exit edit mode when switching modes

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -270,6 +270,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             shopSelectionMode = false;
             selectedShopItems.clear();
 
+            // Exit edit mode when switching modes
+            editMode = false;
+
             currentMode = newMode;
             saveMode();
             updateModeUI();

--- a/tests/exit_edit_mode.test.js
+++ b/tests/exit_edit_mode.test.js
@@ -1,0 +1,37 @@
+const { test, expect } = require('@playwright/test');
+
+test('switching mode exits edit mode', async ({ page }) => {
+  await page.goto('http://localhost:3000#');
+
+  // Seed the state: in home mode with edit mode ON
+  await page.evaluate(() => {
+    localStorage.setItem('grocery-edit-mode', 'true');
+    localStorage.setItem('grocery-mode', 'home');
+  });
+
+  await page.reload();
+
+  const reorderBtn = page.locator('#toolbar-reorder');
+  await expect(reorderBtn).toHaveClass(/active/);
+
+  // Switch to Shop mode
+  const modeBtn = page.locator('#toolbar-mode');
+  await modeBtn.click();
+
+  // Wait for animation or check state
+  await expect(reorderBtn).not.toHaveClass(/active/);
+
+  const editModePersisted = await page.evaluate(() => localStorage.getItem('grocery-edit-mode'));
+  expect(editModePersisted).toBe('false');
+
+  // Switch back to Home mode
+  // Enable edit mode first
+  await reorderBtn.click();
+  await expect(reorderBtn).toHaveClass(/active/);
+
+  await modeBtn.click();
+  await expect(reorderBtn).not.toHaveClass(/active/);
+
+  const editModePersistedAgain = await page.evaluate(() => localStorage.getItem('grocery-edit-mode'));
+  expect(editModePersistedAgain).toBe('false');
+});


### PR DESCRIPTION
The application now automatically exits Edit Mode when switching between Home and Store modes.

Key changes:
- In `public/app.js`, the `switchMode` function was updated to set `editMode = false`.
- Since `switchMode` calls `saveMode()` and `updateModeUI()`, the state is correctly persisted to `localStorage` and the UI (toolbar buttons and container classes) is updated immediately.
- A new Playwright test `tests/exit_edit_mode.test.js` was added to verify this behavior and ensure it remains correct in the future.
- Verified that existing drag-and-drop functionality still works correctly (verified via manual inspection of code and running relevant parts of existing tests).

Fixes #77

---
*PR created automatically by Jules for task [2756744929403056171](https://jules.google.com/task/2756744929403056171) started by @camyoung1234*