### PR TITLE
Adjust strike-through to end at text end

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -556,7 +556,7 @@ h1 {
 }
 
 /* Flare Animation Styles */
-.shop-chip .item-info::after {
+.shop-chip .item-text::after {
     content: '';
     position: absolute;
     left: 0;
@@ -569,16 +569,16 @@ h1 {
     pointer-events: none;
 }
 
-.shop-chip.is-completing .item-info::after {
-    width: calc(100% + 1rem);
+.shop-chip.is-completing .item-text::after {
+    width: 100%;
     transition-delay: 0.3s;
 }
 
-.shop-chip.completed .item-info::after {
-    width: calc(100% + 1rem);
+.shop-chip.completed .item-text::after {
+    width: 100%;
 }
 
-.shop-chip.is-undoing .item-info::after {
+.shop-chip.is-undoing .item-text::after {
     width: 0;
     transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important;
 }
@@ -649,10 +649,6 @@ h1 {
 .shop-chip.is-completing .item-text,
 .shop-chip.completed .item-text {
     color: var(--text-muted) !important;
-}
-
-.shop-chip.completed .item-text::after {
-    width: 0 !important;
 }
 
 .shop-qty-circle .qty-number,


### PR DESCRIPTION
The strike-through animation in Shop mode was previously applied to the `.item-info` container and used a fixed width calculation (`calc(100% + 1rem)`), which often caused it to overshoot the actual text. 

This change moves the strike-through pseudo-element directly to the `.item-text` element and sets its width to `100%`. Since `.item-text` is an `inline-block`, this ensures the strike-through ends precisely at the end of the text. 

The multi-stage 'flare' animation (consisting of the circle fill, sparks, and then the delayed strike-through) is preserved by maintaining the `transition-delay` on the new selector. The rule that previously suppressed the default strike-through on `.item-text` in Shop mode has been removed to allow this new, precisely-aligned strike-through to take effect.

Fixes #79

---
*PR created automatically by Jules for task [12084859496450398451](https://jules.google.com/task/12084859496450398451) started by @camyoung1234*