### PR TITLE
Remove "Add item" rows from store mode

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1630,7 +1630,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 
             // Add "Add item" row for this section
-            {
+            if (isHome) {
                 const addRow = document.createElement('li');
                 addRow.className = 'grocery-item add-item-row';
                 if (isSectionRestoration) addRow.classList.add('restoring-item');

--- a/tests/verify_shop_add_item.spec.js
+++ b/tests/verify_shop_add_item.spec.js
@@ -1,0 +1,101 @@
+const { test, expect } = require('@playwright/test');
+
+test('Add item rows are NOT visible in shop mode when editing', async ({ page }) => {
+  await page.goto('http://localhost:3000#');
+
+  // Seed state: Add a section so we have a place for "Add item"
+  await page.evaluate(() => {
+    const listId = Date.now().toString();
+    const state = {
+      lists: [{
+        id: listId,
+        name: 'Test List',
+        theme: 'var(--theme-blue)',
+        homeSections: [{ id: 'sec-h-1', name: 'Home Section' }],
+        shopSections: [{ id: 'sec-s-1', name: 'Shop Section' }],
+        items: []
+      }],
+      currentListId: listId
+    };
+    localStorage.setItem('grocery-app-state', JSON.stringify(state));
+    localStorage.setItem('grocery-mode', 'shop');
+    localStorage.setItem('grocery-edit-mode', 'true');
+  });
+  await page.reload();
+
+  // If restore modal is visible, click cancel
+  const cancelBtn = page.locator('#restore-cancel-btn');
+  if (await cancelBtn.isVisible()) {
+      await cancelBtn.click();
+  }
+
+  // Switch to Shop mode if not already there (should be seeded, but let's be sure)
+  const modeBtn = page.locator('#toolbar-mode');
+  if (!await page.locator('#toolbar-mode i.fa-shopping-cart').isVisible()) {
+    await modeBtn.click();
+  }
+  await expect(page.locator('#toolbar-mode i')).toHaveClass(/fa-shopping-cart/);
+
+  // Re-enable Edit mode if it was toggled off by mode switch
+  const reorderBtn = page.locator('#toolbar-reorder');
+  if (!await reorderBtn.evaluate(el => el.classList.contains('active'))) {
+      await reorderBtn.click();
+  }
+  await expect(reorderBtn).toHaveClass(/active/);
+
+  // Check if .add-item-row is hidden (after fix)
+  const addItemRow = page.locator('.add-item-row');
+  await expect(addItemRow).not.toBeVisible();
+
+  // Check if .add-section-row IS still visible
+  const addSectionRow = page.locator('.add-section-row');
+  await expect(addSectionRow).toBeVisible();
+});
+
+test('Add item rows ARE visible in home mode when editing', async ({ page }) => {
+  await page.goto('http://localhost:3000#');
+
+  // Seed state: Add a section, Home mode, Edit mode ON
+  await page.evaluate(() => {
+    const listId = Date.now().toString();
+    const state = {
+      lists: [{
+        id: listId,
+        name: 'Test List',
+        theme: 'var(--theme-blue)',
+        homeSections: [{ id: 'sec-h-1', name: 'Home Section' }],
+        shopSections: [{ id: 'sec-s-1', name: 'Shop Section' }],
+        items: []
+      }],
+      currentListId: listId
+    };
+    localStorage.setItem('grocery-app-state', JSON.stringify(state));
+    localStorage.setItem('grocery-mode', 'home');
+    localStorage.setItem('grocery-edit-mode', 'true');
+  });
+  await page.reload();
+
+  // If restore modal is visible, click cancel
+  const cancelBtn = page.locator('#restore-cancel-btn');
+  if (await cancelBtn.isVisible()) {
+      await cancelBtn.click();
+  }
+
+  // Ensure we are in Home mode
+  await expect(page.locator('#toolbar-mode i')).toHaveClass(/fa-home/);
+
+  // Verify Edit mode is ON
+  const reorderBtn = page.locator('#toolbar-reorder');
+  if (!await reorderBtn.evaluate(el => el.classList.contains('active'))) {
+      await reorderBtn.click();
+  }
+  await expect(reorderBtn).toHaveClass(/active/);
+
+  // Check if .add-item-row is visible in Home mode
+  const addItemRow = page.locator('.add-item-row');
+  await expect(addItemRow.first()).toBeVisible();
+
+  // Check if .add-section-row IS visible
+  const addSectionRow = page.locator('.add-section-row');
+  await expect(addSectionRow).toBeVisible();
+});


### PR DESCRIPTION
This change removes the "Add item" rows that were previously visible in Store (Shop) mode when Edit mode was enabled.

Key changes:
- In `public/app.js`, wrapped the "Add item" row creation logic in `if (isHome)`.
- Added `tests/verify_shop_add_item.spec.js` to ensure:
    - "Add item" rows are hidden in Shop mode.
    - "Add item" rows are visible in Home mode.
    - "Add section" rows are visible in both modes.

Verified with Playwright screenshots and existing tests. Pre-existing failure in `tests/drag_fix_verify.test.js` was noted but is unrelated to these changes.

Fixes #82

---
*PR created automatically by Jules for task [10606689070170513527](https://jules.google.com/task/10606689070170513527) started by @camyoung1234*