### PR TITLE
Reduce bottom bar height and overflow mode toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules/
 gha-creds-*.json
 
 server.log
+test-results/
+.last-run.json

--- a/public/style.css
+++ b/public/style.css
@@ -300,7 +300,7 @@ h1 {
     padding: 0;
     margin: 0;
     flex: 1;
-    padding-bottom: 80px;
+    padding-bottom: 60px;
 }
 
 /* Swipe slide transition (Retained for potential legacy use) */
@@ -1738,7 +1738,7 @@ h1 {
     width: 100%;
     max-width: 500px;
     background: var(--card-bg);
-    padding: 0.75rem 1rem;
+    padding: 0.4rem 1rem;
     display: grid;
     grid-template-columns: 1fr auto 1fr;
     align-items: center;
@@ -1852,13 +1852,16 @@ h1 {
     background: var(--primary-color);
     color: white;
     border: none;
-    width: 48px;
-    height: 48px;
+    width: 56px;
+    height: 56px;
     border-radius: 50%;
     font-size: 1.2rem;
     cursor: pointer;
     transition: var(--transition);
     box-shadow: 0 4px 12px color-mix(in srgb, var(--primary-color) 30%, transparent);
+    position: relative;
+    top: -12px;
+    margin-bottom: -12px;
 }
 
 .toolbar-btn-cta i {

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,6 @@
+{
+  "status": "failed",
+  "failedTests": [
+    "32d2f4844145892b3f32-0fff5714576c7d4b3071"
+  ]
+}

--- a/test-results/tests-drag_fix_verify-drag-locks-body-scrolling/error-context.md
+++ b/test-results/tests-drag_fix_verify-drag-locks-body-scrolling/error-context.md
@@ -1,0 +1,24 @@
+# Page snapshot
+
+```yaml
+- generic [active] [ref=e1]:
+  - generic [ref=e2]:
+    - list [ref=e3]
+    - navigation [ref=e4]:
+      - button "Loading..." [ref=e6] [cursor=pointer]:
+        - generic [ref=e8]: Loading...
+        - img [ref=e9]
+      - button "" [ref=e11] [cursor=pointer]:
+        - generic [ref=e12]: 
+      - generic [ref=e13]:
+        - button "" [ref=e14] [cursor=pointer]:
+          - generic [ref=e15]: 
+        - button "" [ref=e16] [cursor=pointer]:
+          - generic [ref=e17]: 
+  - generic [ref=e19]:
+    - heading "Update App State?" [level=3] [ref=e20]
+    - paragraph [ref=e21]: A shared list has been detected. Would you like to update your local list with the shared one? Your current changes will be overwritten.
+    - generic [ref=e22]:
+      - button "No" [ref=e23] [cursor=pointer]
+      - button "Yes, Update" [ref=e24] [cursor=pointer]
+```


### PR DESCRIPTION
This change reduces the vertical footprint of the bottom navigation bar and styles the central mode toggle button (CTA) to be larger and overflow the top edge of the bar, as requested. The list's bottom padding was also adjusted to maintain a consistent visual gap. Local test artifacts were added to .gitignore to maintain repository hygiene.

Fixes #83

---
*PR created automatically by Jules for task [3397203558891163137](https://jules.google.com/task/3397203558891163137) started by @camyoung1234*