### PR TITLE
Fix overlapping rows in large sections

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -2073,7 +2073,7 @@ h1 {
 }
 
 .section-items-list {
-    max-height: 2000px;
+    max-height: 10000px;
     transition: max-height 0.3s ease, opacity 0.3s ease, padding 0.3s ease, margin 0.3s ease;
     min-height: 10px; /* Ensure empty sections are targetable during drag */
 }
@@ -2115,7 +2115,7 @@ h1 {
 }
 
 .section-container {
-    max-height: 2000px; /* Base max-height for transitions */
+    max-height: 10000px; /* Base max-height for transitions */
 }
 
 .no-transition, .no-transition * {

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
This change addresses a layout issue where large sections (approx. 40+ items) would overlap subsequent sections. The root cause was a `max-height: 2000px` constraint on section containers, which was too small for long lists. Increasing this to `10000px` allows sections to grow correctly while maintaining smooth CSS transitions. Verified with Playwright tests.

Fixes #96

---
*PR created automatically by Jules for task [7231814867585893993](https://jules.google.com/task/7231814867585893993) started by @camyoung1234*