### PR TITLE
Simplify modifying counters

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -361,6 +361,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             editMode = !editMode;
             saveMode();
             updateModeUI();
+            renderList();
 
             // Maintain scroll position for the top row
             if (topRow) {
@@ -1203,6 +1204,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     function updateModeUI() {
+        renderList();
         const currentList = getCurrentList();
         const themeColor = currentList && currentList.theme ? currentList.theme : 'var(--theme-blue)';
         document.documentElement.style.setProperty('--primary-color', themeColor);
@@ -1239,7 +1241,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             appContainer.classList.toggle('hide-drag-handles', !editMode);
             appContainer.classList.toggle('home-mode', isHome);
             appContainer.classList.toggle('shop-mode', !isHome);
+            appContainer.classList.toggle('edit-mode-on', editMode);
         }
+        renderList();
     }
 
     function saveAppState() {
@@ -1649,7 +1653,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     const controls = document.createElement('div');
                     controls.className = 'quantity-controls';
 
-                    controls.appendChild(createCombinedQtyControl(item));
+                    controls.appendChild(createSingleQtyControl(item, 'have'));
 
                     li.appendChild(controls);
 
@@ -1712,6 +1716,29 @@ document.addEventListener('DOMContentLoaded', async () => {
                     li.appendChild(createLeftAction([handle, qtyCircle]));
 
                     li.appendChild(info);
+
+                    const controls = document.createElement('div');
+                    controls.className = 'quantity-controls';
+
+                    if (!item.pendingDelete) {
+                        controls.appendChild(createSingleQtyControl(item, 'want', () => {
+                            const currentList = getCurrentList();
+                            if (item.allIds && item.allIds.length > 0) {
+                                item.allIds.forEach((id, idx) => {
+                                    const actualItem = currentList.items.find(i => i.id === id);
+                                    if (actualItem) {
+                                        actualItem.wantCount = (idx === 0) ? item.wantCount : 0;
+                                    }
+                                });
+                                saveAppState();
+                                renderList();
+                            } else {
+                                saveAppState();
+                                renderList();
+                            }
+                        }));
+                    }
+                    li.appendChild(controls);
 
                     // Full-chip click toggle for Shop Mode
                     li.addEventListener('click', (e) => {
@@ -1857,7 +1884,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 if (p !== part) {
                     p.classList.remove('expanded');
                     // Also remove active from the other pill if it's not our own parent
-                    const otherGroup = p.closest('.qty-combined-pill');
+                    const otherGroup = p.closest('.qty-combined-pill, .qty-single-pill');
                     if (otherGroup && otherGroup !== group) {
                         otherGroup.classList.remove('active');
                     }
@@ -1870,66 +1897,66 @@ document.addEventListener('DOMContentLoaded', async () => {
         return { part, valSpan, btnMinus, btnPlus };
     }
 
-    function createCombinedQtyControl(item) {
+    function createSingleQtyControl(item, type, onUpdate) {
         const group = document.createElement('div');
-        group.className = 'qty-combined-pill';
+        group.className = 'qty-single-pill';
 
-        const have = createQtyPart(group, item.haveCount, 'have');
-        const want = createQtyPart(group, item.wantCount, 'want');
+        const value = type === 'have' ? item.haveCount : item.wantCount;
+        const part = createQtyPart(group, value, type);
 
-        const separator = document.createElement('span');
-        separator.className = 'qty-divider';
-        separator.textContent = '/';
-
-        group.appendChild(have.part);
-        group.appendChild(separator);
-        group.appendChild(want.part);
+        group.appendChild(part.part);
 
         const updateUI = (isInit = false) => {
-            const oldHave = have.valSpan.textContent;
-            const oldWant = want.valSpan.textContent;
+            const currentVal = type === 'have' ? item.haveCount : item.wantCount;
+            const oldVal = part.valSpan.textContent;
 
-            have.valSpan.textContent = item.haveCount;
-            want.valSpan.textContent = item.wantCount;
+            part.valSpan.textContent = currentVal;
 
-            if (!isInit) {
-                if (oldHave !== String(item.haveCount)) {
-                    have.valSpan.classList.remove('pop-animate');
-                    void have.valSpan.offsetWidth; // Trigger reflow
-                    have.valSpan.classList.add('pop-animate');
-                }
-                if (oldWant !== String(item.wantCount)) {
-                    want.valSpan.classList.remove('pop-animate');
-                    void want.valSpan.offsetWidth; // Trigger reflow
-                    want.valSpan.classList.add('pop-animate');
-                }
+            if (!isInit && oldVal !== String(currentVal)) {
+                part.valSpan.classList.remove('pop-animate');
+                void part.valSpan.offsetWidth; // Trigger reflow
+                part.valSpan.classList.add('pop-animate');
             }
 
-            if (item.wantCount === 0) {
-                want.part.classList.add('delete-mode');
-            } else {
-                want.part.classList.remove('delete-mode');
+            if (type === 'want') {
+                if (item.wantCount === 0) {
+                    part.part.classList.add('delete-mode');
+                } else {
+                    part.part.classList.remove('delete-mode');
+                }
             }
 
             saveAppState();
+            if (onUpdate) onUpdate();
         };
 
         // Initialize UI state
         updateUI(true);
 
-        have.btnMinus.addEventListener('click', (e) => { e.stopPropagation(); item.haveCount = Math.max(0, item.haveCount - 1); updateUI(); });
-        have.btnPlus.addEventListener('click', (e) => { e.stopPropagation(); item.haveCount++; updateUI(); });
-
-        want.btnMinus.addEventListener('click', (e) => {
+        part.btnMinus.addEventListener('click', (e) => {
             e.stopPropagation();
-            if (item.wantCount === 0) {
-                deleteItem(item.id);
+            if (type === 'have') {
+                item.haveCount = Math.max(0, item.haveCount - 1);
             } else {
-                item.wantCount = Math.max(0, item.wantCount - 1);
-                updateUI();
+                if (item.wantCount === 0) {
+                    deleteItem(item.id);
+                    return;
+                } else {
+                    item.wantCount = Math.max(0, item.wantCount - 1);
+                }
             }
+            updateUI();
         });
-        want.btnPlus.addEventListener('click', (e) => { e.stopPropagation(); item.wantCount++; updateUI(); });
+
+        part.btnPlus.addEventListener('click', (e) => {
+            e.stopPropagation();
+            if (type === 'have') {
+                item.haveCount++;
+            } else {
+                item.wantCount++;
+            }
+            updateUI();
+        });
 
         return group;
     }

--- a/public/style.css
+++ b/public/style.css
@@ -434,7 +434,7 @@ h1 {
 .quantity-controls {
     display: flex;
     align-items: center;
-    width: 104px;
+    width: 52px;
     /* Fix width to enable transition */
     opacity: 1;
     overflow: visible;
@@ -912,7 +912,8 @@ h1 {
 
 /* Quantity Controls (Home Mode - Combined Expandable) */
 
-.qty-combined-pill {
+.qty-combined-pill,
+.qty-single-pill {
     display: flex;
     align-items: center;
     background: color-mix(in srgb, var(--primary-color) 15%, transparent);
@@ -923,12 +924,14 @@ h1 {
 }
 
 @media (hover: hover) {
-    .qty-combined-pill:hover {
+    .qty-combined-pill:hover,
+    .qty-single-pill:hover {
         background: color-mix(in srgb, var(--primary-color) 25%, transparent);
     }
 }
 
-.qty-combined-pill.active {
+.qty-combined-pill.active,
+.qty-single-pill.active {
     background: color-mix(in srgb, var(--primary-color) 25%, transparent);
     /* Offset the exact width added by the two 26px buttons so the layout width is unchanged */
     margin-left: -52px;
@@ -2211,7 +2214,8 @@ h1 {
 }
 
 
-.home-mode:not(.hide-drag-handles) .quantity-controls {
+.home-mode.edit-mode-on .quantity-controls,
+.shop-mode:not(.edit-mode-on) .quantity-controls {
     width: 0;
     opacity: 0;
     transform: scale(0.5);

--- a/repro.spec.js
+++ b/repro.spec.js
@@ -1,0 +1,43 @@
+
+import { test, expect } from '@playwright/test';
+
+test('capture current state', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+
+  // Wait for app to load
+  await page.waitForSelector('.app-container');
+
+  // Seed some items if empty
+  await page.evaluate(() => {
+    localStorage.setItem('grocery-app-state', JSON.stringify({
+      lists: [{
+        id: 'test-list',
+        name: 'Test List',
+        theme: 'var(--theme-blue)',
+        homeSections: [{ id: 'sec-h-def', name: 'Uncategorized' }],
+        shopSections: [{ id: 'sec-s-def', name: 'Uncategorized' }],
+        items: [
+          { id: '1', text: 'Apples', homeSectionId: 'sec-h-def', shopSectionId: 'sec-s-def', homeIndex: 0, shopIndex: 0, haveCount: 2, wantCount: 5, shopCompleted: false },
+          { id: '2', text: 'Milk', homeSectionId: 'sec-h-def', shopSectionId: 'sec-s-def', homeIndex: 1, shopIndex: 1, haveCount: 0, wantCount: 1, shopCompleted: false }
+        ]
+      }],
+      currentListId: 'test-list'
+    }));
+    window.location.reload();
+  });
+
+  await page.waitForSelector('.grocery-item');
+
+  // Screenshot Home Mode
+  await page.screenshot({ path: 'home-mode.png' });
+
+  // Switch to Shop Mode
+  await page.click('#toolbar-mode');
+  await page.waitForTimeout(500); // Wait for transition
+  await page.screenshot({ path: 'shop-mode.png' });
+
+  // Turn on Edit Mode in Shop Mode
+  await page.click('#toolbar-reorder');
+  await page.waitForTimeout(300);
+  await page.screenshot({ path: 'shop-mode-edit.png' });
+});

--- a/tests/verify_counters.spec.js
+++ b/tests/verify_counters.spec.js
@@ -1,0 +1,78 @@
+
+import { test, expect } from '@playwright/test';
+
+test('verify counters in home and shop mode', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+
+  await page.goto('http://localhost:3000#');
+
+  // Seed some items
+  await page.evaluate(() => {
+    localStorage.setItem('grocery-app-state', JSON.stringify({
+      lists: [{
+        id: 'test-list',
+        name: 'Test List',
+        theme: 'var(--theme-blue)',
+        homeSections: [{ id: 'sec-h-def', name: 'Uncategorized' }],
+        shopSections: [{ id: 'sec-s-def', name: 'Uncategorized' }],
+        items: [
+          { id: '1', text: 'Apples', homeSectionId: 'sec-h-def', shopSectionId: 'sec-s-def', homeIndex: 0, shopIndex: 0, haveCount: 2, wantCount: 5, shopCompleted: false }
+        ]
+      }],
+      currentListId: 'test-list'
+    }));
+    localStorage.setItem('grocery-edit-mode', 'false');
+    localStorage.setItem('grocery-mode', 'home');
+    window.location.reload();
+  });
+  await page.waitForSelector('.grocery-item');
+
+  // 1. Verify Home mode: Exit edit mode to see the counter
+  // Note: editMode defaults to true but switchMode(newMode, true) sets it to false.
+  // Actually, init() reads it from localStorage or defaults to true.
+  await page.waitForSelector('.grocery-item');
+
+  // Home mode should show only ONE qty-part (have)
+  const homeControls = page.locator('.grocery-item .quantity-controls');
+  await expect(homeControls).toBeVisible();
+  const havePart = homeControls.locator('.have-part');
+  const wantPart = homeControls.locator('.want-part');
+  await expect(havePart).toBeVisible();
+  await expect(wantPart).not.toBeVisible();
+
+  // 2. Switch to Shop mode
+  await page.click('#toolbar-mode');
+  await page.waitForTimeout(500); // Wait for transition
+
+  // Shop mode (not editing) should have no counters visible
+  const shopControls = page.locator('.grocery-item .quantity-controls');
+  await expect(shopControls.first()).not.toBeVisible();
+
+  // 3. Turn on Edit Mode in Shop Mode
+  await page.click('#toolbar-reorder');
+  await page.waitForTimeout(1000);
+
+  // Shop mode (editing) should show ONLY the want counter
+  await expect(shopControls.first()).toHaveCSS('width', '52px');
+  const shopWantPart = shopControls.locator('.want-part');
+  const shopHavePart = shopControls.locator('.have-part');
+  await expect(shopWantPart).toBeVisible();
+  await expect(shopHavePart).not.toBeVisible();
+
+  // 4. Verify quantity update works in Shop Edit mode
+  await shopWantPart.click(); // Expand it
+  await page.waitForTimeout(300);
+  await shopWantPart.locator('.plus').click();
+  await page.waitForTimeout(300);
+
+  const wantVal = await shopWantPart.locator('.qty-val').textContent();
+  expect(wantVal).toBe('6');
+
+  // 5. Verify Shop mode display (not editing) updates correctly
+  await page.click('#toolbar-reorder'); // Turn off edit mode
+  await page.waitForTimeout(300);
+
+  // toBuy should be wantCount (6) - haveCount (2) = 4
+  const shopQtyCircle = page.locator('.shop-qty-circle .qty-number');
+  await expect(shopQtyCircle).toHaveText('4');
+});


### PR DESCRIPTION
The quantity counters have been simplified to focus on the most relevant information for each mode. In Home mode, users now see only the quantity they currently have. In Shop mode, the desired quantity is hidden by default and only revealed when entering Edit mode, allowing for a cleaner shopping experience while still permitting adjustments.

Technical changes:
- Created `createSingleQtyControl` in `app.js` to handle individual count types.
- Updated `renderList` to use `createSingleQtyControl` with 'have' for Home mode and 'want' for Shop mode (conditionally).
- Reduced `.quantity-controls` width in `style.css` to 52px.
- Implemented CSS rules to manage counter visibility based on the `.edit-mode-on` and mode classes on the app container.

Fixes #100

---
*PR created automatically by Jules for task [16613699667068852412](https://jules.google.com/task/16613699667068852412) started by @camyoung1234*