### PR TITLE
Fix home item dragging ghost controls visibility

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2361,6 +2361,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         touchGhost.classList.add('touch-ghost');
         touchGhost.classList.remove('dragging', 'collapsed');
 
+        // Add current mode class to the ghost so mode-specific styles apply
+        touchGhost.classList.add(currentMode === 'home' ? 'home-mode' : 'shop-mode');
+
         // Lock width and height
         touchGhost.style.width = element.offsetWidth + 'px';
         touchGhost.style.height = (type === 'section' ? 50 : element.offsetHeight) + 'px';

--- a/public/style.css
+++ b/public/style.css
@@ -2203,7 +2203,9 @@ h1 {
 }
 
 .home-mode:not(.hide-drag-handles) .item-delete-btn,
-.home-mode:not(.hide-drag-handles) .section-delete-btn {
+.home-mode:not(.hide-drag-handles) .section-delete-btn,
+.touch-ghost.home-mode .item-delete-btn,
+.touch-ghost.home-mode .section-delete-btn {
     width: 40px;
     opacity: 1;
     transform: scale(1);
@@ -2211,7 +2213,8 @@ h1 {
 }
 
 
-.home-mode:not(.hide-drag-handles) .quantity-controls {
+.home-mode:not(.hide-drag-handles) .quantity-controls,
+.touch-ghost.home-mode .quantity-controls {
     width: 0;
     opacity: 0;
     transform: scale(0.5);


### PR DESCRIPTION
Fixed an issue where dragging an item in Home Mode would cause the 'X' (delete) button to disappear and the quantity stepper to appear in the drag ghost element. This was due to the ghost element being appended to `document.body`, losing its context within the `.app-container` where mode-specific styles are defined.

Changes:
1.  **public/app.js**: Updated `createDragVisual` to explicitly add the current mode class (`home-mode` or `shop-mode`) to the `touchGhost` element.
2.  **public/style.css**: Added selectors for `.touch-ghost.home-mode` to the rules that manage the visibility of `.item-delete-btn`, `.section-delete-btn`, and `.quantity-controls`.

Verified the fix using a new Playwright test that specifically checks the computed opacity of these elements in the drag ghost during a simulated touch drag. Also ran the full test suite to ensure no regressions.

Fixes #110

---
*PR created automatically by Jules for task [4331201276441717890](https://jules.google.com/task/4331201276441717890) started by @camyoung1234*