### PR TITLE
Synchronize strike-through and circle fill animations

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1045,9 +1045,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
             if (newState) {
                 // Completion sequence
-                // 1. Circle fills (check icon appears) immediately (takes 0.3s)
-                // 2. Strike-through starts after 0.3s (takes 0.4s)
-                // Total duration: 0.7s
+                // Both animations start immediately:
+                // 1. Circle fills (check icon appears) takes 0.3s
+                // 2. Strike-through takes 0.4s
+                // Total duration: 0.4s
                 await new Promise(r => setTimeout(r, 300));
 
                 // Trigger sparks after circle fill
@@ -1062,8 +1063,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                     }
                 });
 
-                // Wait for strike-through to complete (0.4s more)
-                await new Promise(r => setTimeout(r, 400));
+                // Wait for strike-through to complete (0.1s more)
+                await new Promise(r => setTimeout(r, 100));
 
                 sameNameItems.forEach(i => {
                     i.shopCompleted = true;

--- a/public/style.css
+++ b/public/style.css
@@ -571,7 +571,6 @@ h1 {
 
 .shop-chip.is-completing .item-text::after {
     width: 100%;
-    transition-delay: 0.3s;
 }
 
 .shop-chip.completed .item-text::after {


### PR DESCRIPTION
This change synchronizes the strike-through animation with the circle-filling animation when checking off items in Store Mode. Previously, the strike-through had a 300ms delay to wait for the circle to fill.

Key changes:
- **CSS:** Removed `transition-delay: 0.3s` from `.shop-chip.is-completing .item-text::after` in `public/style.css`.
- **JS:** Adjusted timing in `toggleShopCompleted` within `public/app.js`. The function now waits 300ms for the circle fill (to trigger sparks) and an additional 100ms for the 400ms strike-through to complete, reducing total completion time from 700ms to 400ms.
- **Verification:** Verified that both animations start simultaneously and the total duration is correct using a Playwright script. All existing tests passed.

Fixes #112

---
*PR created automatically by Jules for task [13289099091930881772](https://jules.google.com/task/13289099091930881772) started by @camyoung1234*