### PR TITLE
Fix theme colored dot alignment in list picker

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1770,13 +1770,13 @@ h1 {
     align-items: center;
     gap: 0.8rem;
     background: transparent;
-    border: none;
+    border: 1px solid transparent;
     color: var(--text-color);
     font-family: inherit;
     font-size: 1rem;
     font-weight: 600;
     cursor: pointer;
-    padding: 0.5rem 0.8rem;
+    padding: calc(0.5rem - 1px) 0.8rem;
     border-radius: 8px;
     transition: var(--transition);
     max-width: 180px;


### PR DESCRIPTION
The theme colored dots in the list picker button and the dropdown menu were slightly misaligned due to the 1px border present on the menu but missing on the button. 

I applied a 1px transparent border to `.list-picker-btn` in `public/style.css` and adjusted its padding using `calc(0.5rem - 1px)` to compensate for the border width. This ensures that the internal content (the swatch and text) aligns perfectly with the items in the dropdown menu without changing the overall size of the button.

Verification:
- Baseline and post-fix screenshots were captured using Playwright.
- Visual inspection confirms the dots are now perfectly aligned.
- All existing Playwright tests passed.
- Temporary test artifacts were removed before submission.

Fixes #111

---
*PR created automatically by Jules for task [16313016994821678400](https://jules.google.com/task/16313016994821678400) started by @camyoung1234*