### PR TITLE
Fix undo button alignment and animation flicker

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -24,6 +24,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     let currentShopFilter = 'unbought'; // 'unbought' or 'all'
     let shopSelectionMode = false; // Tracks whether we're selecting items in shop mode
     let selectedShopItems = new Set(); // Tracks currently selected item IDs
+    let newlyDeletedIds = new Set(); // Tracks items that just entered undo state to trigger animation
     let pendingDeletions = new Map(); // Tracks timeout IDs for items in "Undo" state
     const shopDefId = 'sec-s-def'; // Default Uncategorized ID for Shop Mode
 
@@ -1133,6 +1134,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         // Mark as pending delete
         item.pendingDelete = true;
+        newlyDeletedIds.add(id);
 
         // Save state immediately - items with pendingDelete will be filtered out during save
         saveAppState();
@@ -1575,6 +1577,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
                 if (item.pendingDelete) {
                     li.classList.add('undo-row');
+                    if (newlyDeletedIds.has(item.id)) {
+                        li.classList.add('undo-row-animate');
+                    }
 
                     if (isHome) {
                         const prevItem = sectionItems[idx - 1];
@@ -1823,6 +1828,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         addSecInfo.appendChild(addSecContainer);
         addSecRow.appendChild(addSecInfo);
         groceryList.appendChild(addSecRow);
+
+        newlyDeletedIds.clear();
     }
 
     function createQtyPart(group, value, type) {

--- a/public/style.css
+++ b/public/style.css
@@ -1614,6 +1614,9 @@ h1 {
     height: auto;
     opacity: 1;
     overflow: hidden;
+}
+
+.grocery-item.undo-row-animate {
     animation: undoRowFadeIn 0.3s ease-out;
 }
 
@@ -1635,7 +1638,6 @@ h1 {
 }
 
 .section-container .grocery-item.undo-row {
-    padding: 0;
     height: 50px;
 }
 


### PR DESCRIPTION
This change fixes two issues with the "Undo" functionality:
1. **Alignment:** The "Undo" button was previously touching the right edge of its parent container because of a `padding: 0` override. Removing this override allows it to inherit the standard padding, providing a consistent layout.
2. **Animation Flicker:** When multiple items were in the undo state, deleting or restoring any item would trigger a full list re-render, causing all existing undo rows to restart their entrance animation. By tracking newly deleted IDs and using a specific animation class that is only applied once, existing undo rows remain stable during re-renders.

Fixes #116

---
*PR created automatically by Jules for task [334553774665268460](https://jules.google.com/task/334553774665268460) started by @camyoung1234*