### PR TITLE
Add section delete buttons in store edit mode

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1490,7 +1490,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 header.appendChild(titleSpan);
             }
 
-            if (isHome) {
+            if (canRename) {
                 const secDeleteBtn = document.createElement('button');
                 secDeleteBtn.className = 'section-delete-btn';
                 secDeleteBtn.innerHTML = '<i class="fas fa-times"></i>';

--- a/public/style.css
+++ b/public/style.css
@@ -2201,10 +2201,10 @@ h1 {
     }
 }
 
-.home-mode:not(.hide-drag-handles) .item-delete-btn,
-.home-mode:not(.hide-drag-handles) .section-delete-btn,
-.touch-ghost.home-mode .item-delete-btn,
-.touch-ghost.home-mode .section-delete-btn {
+.app-container:not(.hide-drag-handles) .item-delete-btn,
+.app-container:not(.hide-drag-handles) .section-delete-btn,
+.touch-ghost .item-delete-btn,
+.touch-ghost .section-delete-btn {
     width: 40px;
     opacity: 1;
     transform: scale(1);


### PR DESCRIPTION
This change adds the ability for users to delete sections while in Store Edit mode, matching the behavior in Home Edit mode.

Key changes:
- In `public/app.js`, the logic for rendering the `.section-delete-btn` was updated to use the `canRename` check instead of being strictly limited to `isHome`. This allows the button to appear in Store mode for all sections except the default "Uncategorized" section.
- In `public/style.css`, the visibility rules for `.section-delete-btn` were generalized to apply whenever Edit mode is active (i.e., when `.hide-drag-handles` is not present on the app container), regardless of whether the app is in Home or Store mode.
- Verified that the "Uncategorized" section in Store mode (`sec-s-def`) correctly hides its drag handle and delete button, preserving the application's core data structure.
- Confirmed that Home mode behavior remains unchanged and that all automated tests pass.

Fixes #118

---
*PR created automatically by Jules for task [7602219764459933230](https://jules.google.com/task/7602219764459933230) started by @camyoung1234*