### PR TITLE
Remove section delete drop target

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2078,21 +2078,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                 document.querySelectorAll('.add-item-row').forEach(el => {
                     el.classList.add('collapsed');
                 });
-
-                // Change "Add section" to "Delete"
-                const addSecRow = document.querySelector('.add-section-row');
-                if (addSecRow) {
-                    addSecRow.classList.add('delete-target');
-                    const input = addSecRow.querySelector('.add-section-input');
-                    if (input) {
-                        input.placeholder = 'Delete';
-                        input.disabled = true;
-                    }
-                    const plusIcon = addSecRow.querySelector('.add-row-plus');
-                    if (plusIcon) {
-                        plusIcon.innerHTML = '<i class="fas fa-trash"></i>';
-                    }
-                }
             }
 
             // Performance: cache relevant siblings once at drag start
@@ -2230,12 +2215,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             let targetSelector = dragType === 'section' ? '.section-container, .add-section-row' : '.grocery-item, .section-header, .add-item-row, .add-section-row';
             let target = e.target.closest(targetSelector);
 
-            // Handle delete target visual state
-            document.querySelectorAll('.delete-target').forEach(el => el.classList.remove('drag-over'));
-            if (target && target.classList.contains('delete-target')) {
-                target.classList.add('drag-over');
-            }
-
             if (!target || target === draggedElement || target.classList.contains('drag-placeholder')) return;
 
             if (dragType === 'item') {
@@ -2282,17 +2261,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         const currentList = getCurrentList();
 
         if (dragType === 'section') {
-            const target = e.target.closest('.add-section-row.delete-target');
-            if (target) {
-                const movedId = draggedElement.dataset.id;
-                const section = (isHome ? currentList.homeSections : currentList.shopSections).find(s => s.id === movedId);
-                if (section) {
-                    showSectionDeleteModal(section.id, section.name, isHome);
-                }
-                handleDragEnd();
-                return;
-            }
-
             const sectionsKey = isHome ? 'homeSections' : 'shopSections';
             const sections = currentList[sectionsKey];
             const movedId = draggedElement.dataset.id;
@@ -2420,12 +2388,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             let targetSelector = dragType === 'section' ? '.section-container, .add-section-row' : '.grocery-item, .section-header, .add-item-row, .add-section-row';
             if (target) target = target.closest(targetSelector);
 
-            // Handle delete target visual state
-            document.querySelectorAll('.delete-target').forEach(el => el.classList.remove('drag-over'));
-            if (target && target.classList.contains('delete-target')) {
-                target.classList.add('drag-over');
-            }
-
             if (!target || target === draggedElement || target.classList.contains('drag-placeholder')) return;
 
             if (dragType === 'item') {
@@ -2466,22 +2428,6 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     groceryList.addEventListener('touchend', (e) => {
         if (!draggedElement) return;
-
-        // Manually detect if dropped on delete target for touch since e.target won't work correctly with touch-ghost
-        const touch = e.changedTouches[0];
-        const target = document.elementFromPoint(touch.clientX, touch.clientY)?.closest('.add-section-row.delete-target');
-
-        if (target && dragType === 'section') {
-            const isHome = currentMode === 'home';
-            const movedId = draggedElement.dataset.id;
-            const currentList = getCurrentList();
-            const section = (isHome ? currentList.homeSections : currentList.shopSections).find(s => s.id === movedId);
-            if (section) {
-                showSectionDeleteModal(section.id, section.name, isHome);
-            }
-            handleDragEnd();
-            return;
-        }
 
         if (touchGhost) {
             touchGhost.remove();
@@ -2539,20 +2485,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         draggedElement = null;
         dragType = null;
         
-        // Ensure "Add section" row is fully restored if it was transformed
-        const addSecRow = document.querySelector('.add-section-row');
-        if (addSecRow) {
-            addSecRow.classList.remove('delete-target', 'drag-over');
-            const input = addSecRow.querySelector('.add-section-input');
-            if (input) {
-                input.placeholder = '+ Add section';
-                input.disabled = false;
-            }
-            const plusIcon = addSecRow.querySelector('.add-row-plus');
-            if (plusIcon) {
-                plusIcon.innerHTML = '<i class="fas fa-plus"></i>';
-            }
-        }
 
         renderList();
         isSectionRestoration = false; // Reset

--- a/public/style.css
+++ b/public/style.css
@@ -1579,23 +1579,6 @@ h1 {
     box-sizing: border-box;
 }
 
-.add-section-row.delete-target {
-    color: var(--danger-color);
-}
-
-.add-section-row.delete-target i {
-    color: var(--danger-color);
-}
-
-.add-section-row.delete-target.drag-over {
-    background-color: var(--danger-color) !important;
-    color: white !important;
-}
-
-.add-section-row.delete-target.drag-over i,
-.add-section-row.delete-target.drag-over .add-section-input::placeholder {
-    color: white !important;
-}
 
 /* Undo Row Styles & Animations */
 .grocery-item.undo-row {
@@ -2141,9 +2124,6 @@ h1 {
     transition: none !important;
 }
 
-.add-section-row.delete-target .add-section-input::placeholder {
-    color: var(--danger-color);
-}
 
 .hide-zero-qty .zero-qty-item,
 .hide-zero-qty .zero-qty-section .section-header {


### PR DESCRIPTION
This change removes the "drag sections to delete" feature. Previously, when a section was dragged, the "+ Add section" row transformed into a red "Delete" drop target. This behavior has been removed from the JavaScript logic and CSS. Existing tests pass, and manual verification confirms the UI no longer transforms during section dragging.

Fixes #123

---
*PR created automatically by Jules for task [5171193822592728685](https://jules.google.com/task/5171193822592728685) started by @camyoung1234*