### PR TITLE
Animate item selection in Shop Mode

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -27,6 +27,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     let newlyDeletedIds = new Set(); // Tracks items that just entered undo state to trigger animation
     let pendingDeletions = new Map(); // Tracks timeout IDs for items in "Undo" state
     const shopDefId = 'sec-s-def'; // Default Uncategorized ID for Shop Mode
+    let selectionRenderTimeout = null;
 
     // --- DOM Elements ---
     const groceryList = document.getElementById('grocery-list');
@@ -1505,7 +1506,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 
 
-            if (shopSelectionMode && !isHome) {
+            if (!isHome) {
                 // Reorder Controls or Merge Button
                 const reorderControls = document.createElement('div');
                 reorderControls.className = 'section-reorder-controls';
@@ -1723,9 +1724,9 @@ document.addEventListener('DOMContentLoaded', async () => {
                     li.addEventListener('click', (e) => {
                         if (shopSelectionMode || editMode) {
                             // Selection Mode
-                            if (selectedShopItems.has(item.id)) {
+                            const wasSelected = selectedShopItems.has(item.id);
+                            if (wasSelected) {
                                 selectedShopItems.delete(item.id);
-                                // Auto-exit if empty
                                 if (selectedShopItems.size === 0) {
                                     shopSelectionMode = false;
                                 }
@@ -1733,7 +1734,34 @@ document.addEventListener('DOMContentLoaded', async () => {
                                 shopSelectionMode = true;
                                 selectedShopItems.add(item.id);
                             }
-                            renderList();
+
+                            // Manual DOM updates to trigger CSS transitions immediately
+                            li.classList.toggle('selected', !wasSelected);
+                            groceryList.classList.toggle('shop-selection-mode', shopSelectionMode);
+
+                            // Update neighbors for rounded corners (sel-top/sel-bottom)
+                            const neighbors = [li, li.previousElementSibling, li.nextElementSibling];
+                            neighbors.forEach(el => {
+                                if (el && el.classList.contains('shop-chip')) {
+                                    const elId = el.dataset.id;
+                                    const isElSelected = selectedShopItems.has(elId);
+
+                                    const prev = el.previousElementSibling;
+                                    const next = el.nextElementSibling;
+                                    const isPrevSelected = prev && prev.classList.contains('shop-chip') && selectedShopItems.has(prev.dataset.id);
+                                    const isNextSelected = next && next.classList.contains('shop-chip') && selectedShopItems.has(next.dataset.id);
+
+                                    el.classList.toggle('sel-top', isElSelected && isPrevSelected);
+                                    el.classList.toggle('sel-bottom', isElSelected && isNextSelected);
+                                }
+                            });
+
+                            // Defer renderList to allow transitions to complete
+                            if (selectionRenderTimeout) clearTimeout(selectionRenderTimeout);
+                            selectionRenderTimeout = setTimeout(() => {
+                                renderList();
+                                selectionRenderTimeout = null;
+                            }, 300);
                         } else {
                             // Regular Shop Mode: toggle completion
                             toggleShopCompleted(item.id);

--- a/public/style.css
+++ b/public/style.css
@@ -494,7 +494,7 @@ h1 {
     width: 100%;
     flex: 0 0 auto;
     cursor: pointer;
-    transition: background 0.2s ease, opacity 0.2s ease, height 0.3s cubic-bezier(0.4, 0, 0.2, 1), max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: background 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.2s ease, height 0.3s cubic-bezier(0.4, 0, 0.2, 1), max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1), border-radius 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     user-select: none;
     -webkit-tap-highlight-color: transparent;
     gap: 0.5rem;


### PR DESCRIPTION
This change introduces smooth visual transitions when selecting or deselecting items while in Shop Mode's selection/edit state. 

Key improvements:
- **Instant Visual Feedback:** Manual DOM class updates (`.selected`, `.sel-top`, `.sel-bottom`) trigger CSS transitions immediately upon click.
- **Synchronized Rendering:** Full DOM replacement via `renderList()` is now deferred by 300ms, matching the animation duration, to prevent flickering or interrupted transitions.
- **Smooth Layout Shifts:** Reorder controls in section headers now utilize CSS transitions for visibility, eliminating sudden jumps when entering or exiting selection mode.
- **Neighbor-Aware Styling:** Selection state updates also check immediate neighbors to ensure that 'merged' rounded corners are animated correctly.

Fixes #126

---
*PR created automatically by Jules for task [14550718526018888814](https://jules.google.com/task/14550718526018888814) started by @camyoung1234*