### PR TITLE
Update checkmark completion animation with swell effect

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -316,6 +316,18 @@ h1 {
     }
 }
 
+@keyframes checkmark-swell {
+    0% {
+        transform: translate(-50%, -50%) scale(1);
+    }
+    50% {
+        transform: translate(-50%, -50%) scale(1.4);
+    }
+    100% {
+        transform: translate(-50%, -50%) scale(1);
+    }
+}
+
 @keyframes slideInRight {
     from {
         transform: translateX(30%);
@@ -553,6 +565,11 @@ h1 {
     background: var(--primary-color);
     color: var(--card-bg);
     border-color: var(--primary-color);
+}
+
+.shop-chip.is-completing .shop-qty-circle {
+    animation: checkmark-swell 0.3s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+    transition: none;
 }
 
 /* Flare Animation Styles */


### PR DESCRIPTION
This change adds a "swell" effect to the checkmark circle when an item is completed in Shop mode. The animation scales the circle to 1.4x (matching the existing commit animation's peak scale) and back to 1.0x over 0.3 seconds. The base CSS transition is disabled during this period to ensure the keyframe animation runs smoothly without conflicting with the `all 0.3s` transition. `overflow: hidden` is preserved to keep the internal fill color properly clipped.

Fixes #132

---
*PR created automatically by Jules for task [3677354534393038401](https://jules.google.com/task/3677354534393038401) started by @camyoung1234*