### PR TITLE
Elastic Drag and Drop Animations

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2289,7 +2289,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                                 { transform: 'translateY(0)' }
                             ], {
                                 duration: 400,
-                                easing: 'cubic-bezier(0.2, 0, 0, 1)'
+                                easing: 'cubic-bezier(0.34, 1.56, 0.64, 1)'
                             });
                         }
                     }
@@ -2331,8 +2331,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                     { transform: `translateY(${delta}px)` },
                     { transform: 'translateY(0)' }
                 ], {
-                    duration: 300,
-                    easing: 'cubic-bezier(0.18, 1, 0.32, 1)'
+                    duration: 400,
+                    easing: 'cubic-bezier(0.34, 1.56, 0.64, 1)'
                 });
             }
         });
@@ -2677,7 +2677,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                                 { transform: 'translateY(0)' }
                             ], {
                                 duration: 400,
-                                easing: 'cubic-bezier(0.2, 0, 0, 1)'
+                                easing: 'cubic-bezier(0.34, 1.56, 0.64, 1)'
                             });
                         }
                     }
@@ -2710,8 +2710,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 { top: ghost.style.top, left: ghost.style.left },
                 { top: phRect.top + 'px', left: phRect.left + 'px' }
             ], {
-                duration: 350,
-                easing: 'cubic-bezier(0.18, 1, 0.32, 1)',
+                duration: 400,
+                easing: 'cubic-bezier(0.34, 1.56, 0.64, 1)',
                 fill: 'forwards'
             });
             anim.onfinish = finalize;


### PR DESCRIPTION
This update enhances the drag-and-drop experience by adding an elastic overshoot effect when items move to make room for the drop target, and when the dropped item snaps into place. This was achieved by updating the CSS timing functions to a `cubic-bezier` with a Y2 value greater than 1.0 and increasing the animation duration.

Fixes #134

---
*PR created automatically by Jules for task [13239337378082300077](https://jules.google.com/task/13239337378082300077) started by @camyoung1234*