### PR TITLE
Update mode toggle button animation

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1864,12 +1864,16 @@ h1 {
 }
 
 .toolbar-btn-cta i {
-    transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.3s;
+    transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.4s ease;
+}
+
+.toolbar-btn-cta.mode-switching {
+    animation: toolbar-cta-swell 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .toolbar-btn-cta.mode-switching i {
     opacity: 0;
-    transform: scale(0.4) rotate(-90deg);
+    transform: scale(0.4);
 }
 
 @media (hover: hover) {
@@ -2261,4 +2265,22 @@ h1 {
     width: 3px;
     height: 3px;
     z-index: 10001;
+}
+
+@keyframes toolbar-cta-swell {
+    0% {
+        transform: scale(1);
+    }
+    30% {
+        transform: scale(1.4);
+    }
+    60% {
+        transform: scale(0.95);
+    }
+    80% {
+        transform: scale(1.05);
+    }
+    100% {
+        transform: scale(1);
+    }
 }


### PR DESCRIPTION
This change updates the mode toggle button animation to include a swell effect with an elastic overshoot when the mode is switched. It also modifies the icon transition to use a combination of resizing (scaling) and fading (opacity), providing a smoother and more modern feel compared to the previous rotation-based transition.

Key changes:
- Defined `toolbar-cta-swell` keyframes in `public/style.css`.
- Applied the animation to the `.mode-switching` class of the toolbar CTA button.
- Simplified the icon transition inside the button by removing `rotate(-90deg)` and using `scale(0.4)` and `opacity: 0` for the exit state.
- Verified the changes with a Playwright script and visual inspection.
- Ensured all existing tests pass.

Fixes #135

---
*PR created automatically by Jules for task [4980021608135198119](https://jules.google.com/task/4980021608135198119) started by @camyoung1234*