### PR TITLE
Disable double-tap to edit item name in shop mode

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1829,22 +1829,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                     textSpan.className = 'item-text';
                     textSpan.textContent = item.text;
 
-                    onDoubleTap(textSpan, (e) => {
-                        if (!editMode) return;
-                        e.stopPropagation();
-                        startInlineItemEdit(item, info, textSpan, (newName) => {
-                            const currentList = getCurrentList();
-                            // Update all items in this group
-                            currentList.items.forEach(i => {
-                                if (i.text === item.text) {
-                                    i.text = newName;
-                                }
-                            });
-                            saveAppState();
-                        });
-                    });
-
-
                     info.appendChild(textSpan);
 
                     const qtyCircle = document.createElement('div');

--- a/tests/double_tap_shop.test.js
+++ b/tests/double_tap_shop.test.js
@@ -1,0 +1,56 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('http://localhost:3000');
+});
+
+test('Double tap on item in Shop mode should NOT trigger inline edit', async ({ page }) => {
+  await page.evaluate(() => {
+    const listId = 'test-list-1';
+    const state = {
+      lists: [{
+        id: listId,
+        name: 'Test List',
+        theme: 'var(--theme-blue)',
+        homeSections: [{ id: 'sec-h-1', name: 'Home Section' }],
+        shopSections: [{ id: 'sec-s-1', name: 'Shop Section' }],
+        items: [{
+            id: 'item-1',
+            text: 'Test Item',
+            homeSectionId: 'sec-h-1',
+            shopSectionId: 'sec-s-1',
+            homeIndex: 0,
+            shopIndex: 0,
+            haveCount: 0,
+            wantCount: 1,
+            shopCompleted: false
+        }]
+      }],
+      currentListId: listId
+    };
+    localStorage.setItem('grocery-app-state', JSON.stringify(state));
+    localStorage.setItem('grocery-mode', 'shop');
+    localStorage.setItem('grocery-edit-mode', 'true');
+  });
+  await page.reload();
+
+  const cancelBtn = page.locator('#restore-cancel-btn');
+  if (await cancelBtn.isVisible()) {
+      await cancelBtn.click();
+  }
+
+  const itemText = page.locator('.grocery-item.shop-chip .item-text');
+  await expect(itemText).toBeVisible();
+
+  await expect(page.locator('#toolbar-reorder')).toHaveClass(/active/);
+
+  // Perform double click
+  await itemText.dblclick();
+
+  // Check if inline edit input appears.
+  const inlineInput = page.locator('.inline-edit-input');
+
+  // IT SHOULD NOW BE HIDDEN
+  await expect(inlineInput).not.toBeVisible();
+});


### PR DESCRIPTION
This change disables the double-tap gesture for editing item names in Shop mode to prevent interference with selection. Double-tap editing remains functional in Home mode. A regression test was added in `tests/double_tap_shop.test.js`.

Fixes #136

---
*PR created automatically by Jules for task [8830988218701734694](https://jules.google.com/task/8830988218701734694) started by @camyoung1234*