### PR TITLE
Change mode toggle button and preserve edit mode

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -278,9 +278,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             shopSelectionMode = false;
             selectedShopItems.clear();
 
-            // Exit edit mode when switching modes
-            editMode = false;
-
             currentMode = newMode;
             saveMode();
             updateModeUI();
@@ -295,10 +292,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Mode fade transition: out → scroll & switch → in
         const fadeOutClass = 'mode-fade-out';
         const fadeInClass = 'mode-fade-in';
-
-        if (toolbarModeBtn) {
-            toolbarModeBtn.classList.add('mode-switching');
-        }
 
         groceryList.classList.add(fadeOutClass);
         groceryList.addEventListener('animationend', function onOut() {
@@ -315,9 +308,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             groceryList.addEventListener('animationend', function onIn() {
                 groceryList.removeEventListener('animationend', onIn);
                 groceryList.classList.remove(fadeInClass);
-                if (toolbarModeBtn) {
-                    toolbarModeBtn.classList.remove('mode-switching');
-                }
             }, { once: true });
         }, { once: true });
     }
@@ -1367,15 +1357,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         // Update toolbar mode CTA
         if (toolbarModeBtn) {
-            const icon = toolbarModeBtn.querySelector('i');
-
-            if (currentMode === 'shop') {
-                if (icon) icon.className = 'fas fa-shopping-cart';
-                toolbarModeBtn.title = 'Switch to Home Mode';
-            } else {
-                if (icon) icon.className = 'fas fa-home';
-                toolbarModeBtn.title = 'Switch to Store Mode';
-            }
+            toolbarModeBtn.classList.toggle('active', currentMode === 'shop');
+            toolbarModeBtn.title = currentMode === 'shop' ? 'Switch to Home Mode' : 'Switch to Store Mode';
         }
 
         if (toolbarReorderBtn) {

--- a/public/index.html
+++ b/public/index.html
@@ -58,11 +58,10 @@
                 </button>
             </div>
 
-            <button class="toolbar-btn-cta" id="toolbar-mode" title="Toggle Mode">
-                <i class="fas fa-home"></i>
-            </button>
-
             <div class="toolbar-actions">
+                <button class="toolbar-btn" id="toolbar-mode" title="Toggle Mode">
+                    <i class="fas fa-list-check"></i>
+                </button>
                 <button class="toolbar-btn" id="toolbar-reorder" title="Exit Edit Mode">
                     <i class="fas fa-pen"></i>
                 </button>

--- a/public/style.css
+++ b/public/style.css
@@ -1742,7 +1742,7 @@ h1 {
     background: var(--card-bg);
     padding: 0.75rem 1rem;
     display: grid;
-    grid-template-columns: 1fr auto 1fr;
+    grid-template-columns: 1fr auto;
     align-items: center;
     box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.05);
     border-top: 1px solid var(--border-color);
@@ -1847,42 +1847,6 @@ h1 {
     color: var(--primary-color);
 }
 
-.toolbar-btn-cta {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--primary-color);
-    color: white;
-    border: none;
-    width: 48px;
-    height: 48px;
-    border-radius: 50%;
-    font-size: 1.2rem;
-    cursor: pointer;
-    transition: var(--transition);
-    box-shadow: 0 4px 12px color-mix(in srgb, var(--primary-color) 30%, transparent);
-}
-
-.toolbar-btn-cta i {
-    transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.3s;
-}
-
-.toolbar-btn-cta.mode-switching i {
-    opacity: 0;
-    transform: scale(0.4) rotate(-90deg);
-}
-
-@media (hover: hover) {
-    .toolbar-btn-cta:hover {
-        filter: brightness(1.1);
-        transform: translateY(-1px);
-        box-shadow: 0 6px 16px color-mix(in srgb, var(--primary-color) 40%, transparent);
-    }
-}
-
-.toolbar-btn-cta:active {
-    transform: translateY(0) scale(0.98);
-}
 
 .dropdown-arrow {
     width: 0.8rem;

--- a/tests/exit_edit_mode.test.js
+++ b/tests/exit_edit_mode.test.js
@@ -1,6 +1,6 @@
 const { test, expect } = require('@playwright/test');
 
-test('switching mode exits edit mode', async ({ page }) => {
+test('switching mode preserves edit mode', async ({ page }) => {
   await page.goto('http://localhost:3000#');
 
   // Seed the state: in home mode with edit mode ON
@@ -18,20 +18,16 @@ test('switching mode exits edit mode', async ({ page }) => {
   const modeBtn = page.locator('#toolbar-mode');
   await modeBtn.click();
 
-  // Wait for animation or check state
-  await expect(reorderBtn).not.toHaveClass(/active/);
-
-  const editModePersisted = await page.evaluate(() => localStorage.getItem('grocery-edit-mode'));
-  expect(editModePersisted).toBe('false');
-
-  // Switch back to Home mode
-  // Enable edit mode first
-  await reorderBtn.click();
+  // Edit mode should be preserved
   await expect(reorderBtn).toHaveClass(/active/);
 
+  const editModePersisted = await page.evaluate(() => localStorage.getItem('grocery-edit-mode'));
+  expect(editModePersisted).toBe('true');
+
+  // Switch back to Home mode
   await modeBtn.click();
-  await expect(reorderBtn).not.toHaveClass(/active/);
+  await expect(reorderBtn).toHaveClass(/active/);
 
   const editModePersistedAgain = await page.evaluate(() => localStorage.getItem('grocery-edit-mode'));
-  expect(editModePersistedAgain).toBe('false');
+  expect(editModePersistedAgain).toBe('true');
 });

--- a/tests/repro_bug.test.js
+++ b/tests/repro_bug.test.js
@@ -40,7 +40,7 @@ test('Clicking on item name in Shop mode toggles completion', async ({ page }) =
   }
 
   // Ensure we are in Shop mode
-  await expect(page.locator('#toolbar-mode i')).toHaveClass(/fa-shopping-cart/);
+  await expect(page.locator('#toolbar-mode')).toHaveClass(/active/);
 
   const itemText = page.locator('.grocery-item.shop-chip .item-text');
   await expect(itemText).toHaveText('Test Item');

--- a/tests/verify_shop_add_item.spec.js
+++ b/tests/verify_shop_add_item.spec.js
@@ -31,10 +31,10 @@ test('Add item rows are NOT visible in shop mode when editing', async ({ page })
 
   // Switch to Shop mode if not already there (should be seeded, but let's be sure)
   const modeBtn = page.locator('#toolbar-mode');
-  if (!await page.locator('#toolbar-mode i.fa-shopping-cart').isVisible()) {
+  if (!await modeBtn.evaluate(el => el.classList.contains('active'))) {
     await modeBtn.click();
   }
-  await expect(page.locator('#toolbar-mode i')).toHaveClass(/fa-shopping-cart/);
+  await expect(modeBtn).toHaveClass(/active/);
 
   // Re-enable Edit mode if it was toggled off by mode switch
   const reorderBtn = page.locator('#toolbar-reorder');
@@ -82,7 +82,7 @@ test('Add item rows ARE visible in home mode when editing', async ({ page }) => 
   }
 
   // Ensure we are in Home mode
-  await expect(page.locator('#toolbar-mode i')).toHaveClass(/fa-home/);
+  await expect(page.locator('#toolbar-mode')).not.toHaveClass(/active/);
 
   // Verify Edit mode is ON
   const reorderBtn = page.locator('#toolbar-reorder');


### PR DESCRIPTION
The mode toggle button has been moved from a central circular button to a standard icon button (checklist icon) located in the actions group on the right side of the toolbar. Additionally, the application now preserves the Edit Mode state when switching between Home and Shop modes. The toolbar layout was updated to a two-column grid, and existing tests were updated to verify these changes.

Fixes #140

---
*PR created automatically by Jules for task [2196204166351062855](https://jules.google.com/task/2196204166351062855) started by @camyoung1234*