### PR TITLE
Add elastic animations for edit mode transitions

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -440,7 +440,7 @@ h1 {
     min-width: 0;
     overflow: visible;
     position: relative;
-    transition: margin 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: margin 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .quantity-controls {
@@ -453,7 +453,7 @@ h1 {
     /* Changed from hidden to allow expansion overlay */
     position: relative;
     z-index: 10;
-    transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1), transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    transition: width 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 
@@ -1990,7 +1990,7 @@ h1 {
 }
 
 .section-title {
-    transition: margin 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: margin 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .left-action {
@@ -2001,7 +2001,7 @@ h1 {
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease, margin-right 0.3s ease;
+    transition: width 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.3s ease, margin-right 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .hide-drag-handles .section-header .left-action {
@@ -2020,7 +2020,7 @@ h1 {
     color: var(--text-muted);
     cursor: grab;
     flex-shrink: 0;
-    transition: opacity 0.3s ease, transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: opacity 0.3s ease, transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
     overflow: hidden;
     position: absolute;
     top: 50%;
@@ -2086,7 +2086,7 @@ h1 {
     height: 50px;
     max-height: 50px;
     overflow: hidden;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
     flex-wrap: nowrap !important;
 }
 
@@ -2112,7 +2112,7 @@ h1 {
 .grocery-item,
 .section-container,
 .section-header {
-    transition: transform 0.2s ease, height 0.3s cubic-bezier(0.4, 0, 0.2, 1), max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1), margin 0.3s cubic-bezier(0.4, 0, 0.2, 1), padding 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: transform 0.2s ease, height 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), max-height 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), margin 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), padding 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .section-container {
@@ -2186,7 +2186,7 @@ h1 {
     height: 50px;
     align-items: center;
     justify-content: center;
-    transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1), transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    transition: width 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
     opacity: 0;
     transform: scale(0.5);
     pointer-events: none;


### PR DESCRIPTION
Updated multiple CSS transition rules to use the elastic cubic-bezier(0.34, 1.56, 0.64, 1) timing function. This provides a springy overshoot effect when entering or exiting edit mode, affecting element reveals/hides and layout shifts for items and sections.

Fixes #142

---
*PR created automatically by Jules for task [777728829630448207](https://jules.google.com/task/777728829630448207) started by @camyoung1234*