### PR TITLE
Reduce item indentation in Home Mode

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1974,6 +1974,10 @@ h1 {
     margin-right: -0.5rem;
 }
 
+.app-container.home-mode.hide-drag-handles .grocery-item .left-action {
+    width: 12px;
+}
+
 /* Drag and Drop Styles */
 .drag-handle {
     width: 40px;

--- a/tests/indentation.test.js
+++ b/tests/indentation.test.js
@@ -71,8 +71,10 @@ test('verify indentation behavior', async ({ page }) => {
   // Section header should have moved left
   expect(sectionX_EditOff).toBeLessThan(sectionX_EditOn);
 
-  // Item text should NOT have moved significantly
-  expect(Math.abs(itemX_EditOff - itemX_EditOn)).toBeLessThan(10);
+  // Item text should have moved left (reduced indentation)
+  expect(itemX_EditOff).toBeLessThan(itemX_EditOn);
+  // Expecting a shift of approx 28px (40px -> 12px)
+  expect(itemX_EditOn - itemX_EditOff).toBeGreaterThan(20);
 
   // --- SHOP MODE ---
   console.log('Testing Shop Mode...');


### PR DESCRIPTION
The item indentation on the Home page has been reduced for better visual balance when not editing. The items now shift smoothly to the right when Edit Mode is activated to make room for drag handles. All existing tests have been updated and verified to pass.

Fixes #148

---
*PR created automatically by Jules for task [4617402507378808883](https://jules.google.com/task/4617402507378808883) started by @camyoung1234*