### PR TITLE
Add custom SVG cloud sync icons

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -16,6 +16,9 @@ const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const db = getFirestore(app);
 
+const SYNC_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 2v6h-6"/><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M3 22v-6h6"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/></svg>`;
+const SYNC_SLASH_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 2v6h-6"/><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M3 22v-6h6"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><line x1="2" y1="2" x2="22" y2="22"/></svg>`;
+
 document.addEventListener('DOMContentLoaded', async () => {
     // --- State ---
     let appState = {
@@ -481,7 +484,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 syncLoggedInDiv.classList.remove('hidden');
                 syncUserEmailSpan.textContent = user.email;
                 if (syncIcon) {
-                    syncIcon.className = 'fas fa-cloud';
+                    syncIcon.innerHTML = SYNC_ICON_SVG;
                 }
                 firstSync = true; // Reset for new user session
                 syncWithFirestore(user);
@@ -489,7 +492,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 syncLoggedOutDiv.classList.remove('hidden');
                 syncLoggedInDiv.classList.add('hidden');
                 if (syncIcon) {
-                    syncIcon.className = 'fas fa-cloud-slash';
+                    syncIcon.innerHTML = SYNC_SLASH_ICON_SVG;
                 }
                 if (unsubscribeFirestore) {
                     unsubscribeFirestore();

--- a/public/index.html
+++ b/public/index.html
@@ -69,7 +69,7 @@
                     <i class="fas fa-pen"></i>
                 </button>
                 <button class="toolbar-btn" id="toolbar-sync" title="Cloud Sync">
-                    <i id="sync-icon" class="fas fa-cloud-slash"></i>
+                    <span id="sync-icon" class="sync-icon"></span>
                 </button>
             </div>
         </nav>

--- a/public/style.css
+++ b/public/style.css
@@ -1776,7 +1776,16 @@ h1 {
     color: var(--primary-color);
 }
 
+.sync-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
 
+.sync-icon svg {
+    width: 20px;
+    height: 20px;
+}
 
 .dropdown-arrow {
     width: 0.8rem;


### PR DESCRIPTION
The cloud backup icon was missing because it relied on FontAwesome classes that were not displaying correctly or were mismatched with the logic. This PR replaces the icon with custom inline SVGs as requested. 

A two-arrow loop icon with a slash is now shown when the user is not synced (logged out), and a standard two-arrow loop icon is shown when sync is enabled (logged in). The icons are properly styled and centered within the toolbar button.

Key changes:
- Defined SYNC_ICON_SVG and SYNC_SLASH_ICON_SVG constants in app.js.
- Updated index.html to use a container for the dynamic SVG.
- Modified app.js to inject the correct SVG based on auth state.
- Added CSS for the .sync-icon container and SVG dimensions.
- Verified all 16 existing Playwright tests pass.

Fixes #205

---
*PR created automatically by Jules for task [4498379506811578616](https://jules.google.com/task/4498379506811578616) started by @camyoung1234*