### PR TITLE
Add animated gradient to 'Add item' and 'Add section' rows

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -294,8 +294,13 @@ h1 {
 }
 
 .inline-item-input::placeholder {
-    color: color-mix(in srgb, var(--primary-color) 60%, var(--card-bg));
+    background-image: conic-gradient(from var(--glow-angle), var(--primary-color), var(--accent-color), var(--primary-color));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    animation: rotate-glow 3s linear infinite;
     font-weight: 500;
+    opacity: 1;
 }
 
 /* Grocery List */
@@ -1961,7 +1966,11 @@ h1 {
 
 .drag-handle.add-row-plus {
     cursor: pointer;
-    color: color-mix(in srgb, var(--primary-color) 60%, var(--card-bg));
+    background-image: conic-gradient(from var(--glow-angle), var(--primary-color), var(--accent-color), var(--primary-color));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    animation: rotate-glow 3s linear infinite;
 }
 
 .drag-handle:active:not(.add-row-plus) {


### PR DESCRIPTION
I have added an animated gradient effect to the "Add item" and "Add section" rows in the grocery list application. 

Key changes:
1.  **CSS Enhancements**: Modified `public/style.css` to apply a rotating `conic-gradient` to the placeholder text of add-item and add-section inputs. This uses the same `--primary-color`, `--accent-color`, and `rotate-glow` animation already used for input borders, ensuring a consistent design language.
2.  **Icon Styling**: Applied the same animated gradient effect to the plus icons (`.drag-handle.add-row-plus`) so that the entire "Add" row visual prompt is synchronized.
3.  **Visual Consistency**: Forced `opacity: 1` on placeholders to ensure the gradient colors are vibrant and correctly clipped to the text.
4.  **Verification**: 
    - Created and ran a Playwright script to visually confirm the animation on both mobile-style and desktop-style layouts.
    - Ran the full suite of 16 existing tests to ensure no regressions in list management, indentation, or shop mode behavior.
    - Cleaned up all temporary verification assets before submission.

Fixes #209

---
*PR created automatically by Jules for task [9196888922127585791](https://jules.google.com/task/9196888922127585791) started by @camyoung1234*