### PR TITLE
🧹 Remove unused createLeftAction function

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1940,17 +1940,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         return handle;
     }
 
-    function createLeftAction(children = []) {
-        const leftAction = document.createElement('div');
-        leftAction.className = 'left-action';
-        if (Array.isArray(children)) {
-            children.forEach(child => leftAction.appendChild(child));
-        } else if (children) {
-            leftAction.appendChild(children);
-        }
-        return leftAction;
-    }
-
     function renderList() {
         const fragment = document.createDocumentFragment();
         const currentList = getCurrentList();


### PR DESCRIPTION
🎯 **What:** The `createLeftAction` function was removed from `public/app.js`.
💡 **Why:** It was an unused function, making it dead code. Removing it slims down the file, reducing cognitive load and improving code maintainability.
✅ **Verification:** Ran Playwright tests which passed successfully, verifying that no active functionality relied on this function.
✨ **Result:** A cleaner `public/app.js` file with no unused dead code regarding `createLeftAction`.

---
*PR created automatically by Jules for task [59472887186306707](https://jules.google.com/task/59472887186306707) started by @camyoung1234*