### PR TITLE
🧹 Remove unused `restoreList` function from `public/app.js`

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2255,37 +2255,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         groceryList.appendChild(document.querySelector('.add-section-row'));
     }
 
-    function restoreList() {
-        const elements = Array.from(groceryList.children);
-        const sections = Array.from(groceryList.querySelectorAll('.section-container'));
-        const sectionMap = new Map();
-        
-        sections.forEach(s => {
-            sectionMap.set(s.dataset.id, s);
-            const list = s.querySelector('.section-items-list');
-            list.innerHTML = ''; // Clear for rebuild
-            s.style.display = '';
-        });
-
-        let currentSectionId = null;
-        elements.forEach(el => {
-            if (el.classList.contains('section-header')) {
-                currentSectionId = el.dataset.originalSectionId;
-            } else if (el.classList.contains('grocery-item') || el.classList.contains('add-item-row') || el === placeholder) {
-                const targetId = el.dataset.originalSectionId || currentSectionId;
-                const section = sectionMap.get(targetId);
-                if (section) {
-                    section.querySelector('.section-items-list').appendChild(el);
-                }
-            } else if (el.classList.contains('add-section-row')) {
-                groceryList.appendChild(el); // Stays at bottom
-            }
-        });
-        
-        // Re-append sections in their current order (if they moved)
-        sections.forEach(s => groceryList.appendChild(s));
-    }
-
     function handleDragStart(e, element, type) {
         if (!editMode) {
             e.preventDefault();


### PR DESCRIPTION
🎯 **What:** Removed the unused `restoreList` function from `public/app.js`.
💡 **Why:** This function was dead code and not called anywhere in the project. Removing it reduces code bloat and improves maintainability.
✅ **Verification:** Verified by running the test suite (`npx playwright test`), which passed successfully, confirming no regressions. 
✨ **Result:** A cleaner `public/app.js` file with reduced unused code overhead.

---
*PR created automatically by Jules for task [1525907154357896508](https://jules.google.com/task/1525907154357896508) started by @camyoung1234*