### PR TITLE
🧪 Add test coverage for inline item edit

### DIFF
--- a/tests/inline_item_edit.spec.js
+++ b/tests/inline_item_edit.spec.js
@@ -1,0 +1,126 @@
+const { test, expect } = require('@playwright/test');
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('http://localhost:3000');
+});
+
+test.describe('startInlineItemEdit in Home Mode', () => {
+
+  test.beforeEach(async ({ page }) => {
+    await page.evaluate(() => {
+      const listId = 'test-list-1';
+      const state = {
+        lists: [{
+          id: listId,
+          name: 'Test List',
+          theme: 'var(--theme-blue)',
+          homeSections: [{ id: 'sec-h-1', name: 'Home Section' }],
+          shopSections: [{ id: 'sec-s-1', name: 'Shop Section' }],
+          items: [
+            {
+              id: 'item-1',
+              text: 'Apple',
+              homeSectionId: 'sec-h-1',
+              shopSectionId: 'sec-s-1',
+              homeIndex: 0,
+              shopIndex: 0,
+              haveCount: 0,
+              wantCount: 1,
+              shopCompleted: false
+            },
+            {
+              id: 'item-2',
+              text: 'Banana',
+              homeSectionId: 'sec-h-1',
+              shopSectionId: 'sec-s-1',
+              homeIndex: 1,
+              shopIndex: 1,
+              haveCount: 0,
+              wantCount: 5,
+              shopCompleted: false
+            }
+          ]
+        }],
+        currentListId: listId
+      };
+      localStorage.setItem('grocery-app-state', JSON.stringify(state));
+      localStorage.setItem('grocery-mode', 'home');
+      localStorage.setItem('grocery-edit-mode', 'true');
+    });
+    await page.reload();
+
+    const cancelBtn = page.locator('#restore-cancel-btn');
+    if (await cancelBtn.isVisible()) {
+        await cancelBtn.click();
+    }
+  });
+
+  test('Happy Path: Edit and save by pressing Enter', async ({ page }) => {
+    const item1Text = page.locator('.grocery-item[data-id="item-1"] .item-text');
+    await expect(item1Text).toHaveText('Apple');
+
+    // Double click to edit
+    await item1Text.dblclick();
+
+    const inlineInput = page.locator('.inline-edit-input');
+    await expect(inlineInput).toBeVisible();
+    await expect(inlineInput).toHaveValue('Apple');
+
+    // Type new name and press Enter
+    await inlineInput.fill('Green Apple');
+    await inlineInput.press('Enter');
+
+    // Check if new name is saved and visible
+    await expect(inlineInput).not.toBeVisible();
+    await expect(page.locator('.grocery-item[data-id="item-1"] .item-text')).toHaveText('Green Apple');
+  });
+
+  test('Cancel Path: Edit and abort by pressing Escape', async ({ page }) => {
+    const item1Text = page.locator('.grocery-item[data-id="item-1"] .item-text');
+    await expect(item1Text).toHaveText('Apple');
+
+    // Double click to edit
+    await item1Text.dblclick();
+
+    const inlineInput = page.locator('.inline-edit-input');
+    await expect(inlineInput).toBeVisible();
+
+    // Type new name but press Escape
+    await inlineInput.fill('Green Apple');
+    await inlineInput.press('Escape');
+
+    // Check if original name is restored
+    await expect(inlineInput).not.toBeVisible();
+    await expect(page.locator('.grocery-item[data-id="item-1"] .item-text')).toHaveText('Apple');
+  });
+
+  test('Inherit WantCount: Rename item to match another item', async ({ page }) => {
+    const item1Text = page.locator('.grocery-item[data-id="item-1"] .item-text');
+
+    // Initial want counts can be checked in local storage
+    let stateJson = await page.evaluate(() => localStorage.getItem('grocery-app-state'));
+    let state = JSON.parse(stateJson);
+    expect(state.lists[0].items.find(i => i.id === 'item-1').wantCount).toBe(1);
+    expect(state.lists[0].items.find(i => i.id === 'item-2').wantCount).toBe(5);
+
+    // Double click to edit Apple
+    await item1Text.dblclick();
+
+    const inlineInput = page.locator('.inline-edit-input');
+    await expect(inlineInput).toBeVisible();
+
+    // Type name to match Banana
+    await inlineInput.fill('Banana');
+    await inlineInput.press('Enter');
+
+    // Check if wantCount for item 1 updated to 5 to match item 2 (Banana)
+    // Let's check localStorage.
+
+    stateJson = await page.evaluate(() => localStorage.getItem('grocery-app-state'));
+    state = JSON.parse(stateJson);
+    const item1 = state.lists[0].items.find(i => i.id === 'item-1');
+
+    expect(item1.text).toBe('Banana');
+    expect(item1.wantCount).toBe(5);
+  });
+});


### PR DESCRIPTION
🎯 **What:** Adds test coverage for the `startInlineItemEdit` functionality.
📊 **Coverage:** The new test file covers the happy path (saving with Enter), the cancel path (aborting with Escape), and an edge case where changing an item's name to match an existing item correctly inherits the `wantCount`.
✨ **Result:** Increased reliability and confidence when refactoring the inline edit functionality.

---
*PR created automatically by Jules for task [12479755535400475617](https://jules.google.com/task/12479755535400475617) started by @camyoung1234*