### PR TITLE
🧹 Remove unused renameItem function

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -334,11 +334,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     const currentAccentSwatch = document.getElementById('current-accent-swatch');
     const currentAccentName = document.getElementById('current-accent-name');
 
-    const modalHomeSectionGroup = document.getElementById('modal-home-section-group');
-    const modalShopSectionGroup = document.getElementById('modal-shop-section-group');
-    const modalHomeSectionSelect = document.getElementById('modal-home-section');
-    const modalShopSectionSelect = document.getElementById('modal-shop-section');
-
     // Import / Export Elements
     const importBtn = document.getElementById('import-btn');
     const exportBtn = document.getElementById('export-btn');
@@ -1030,9 +1025,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             currentDeleteActionCallback = null;
         }
 
-        modalHomeSectionGroup.classList.add('hidden');
-        modalShopSectionGroup.classList.add('hidden');
-
         currentModalCallback = callback;
         modalOverlay.classList.add('visible');
 
@@ -1422,48 +1414,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         container.appendChild(input);
         info.replaceChild(container, nameSpan);
         input.focus();
-    }
-
-    function renameItem(id) {
-        const currentList = getCurrentList();
-        const item = currentList.items.find(i => i.id === id);
-        if (!item) return;
-
-        modalHomeSectionSelect.innerHTML = '';
-        currentList.homeSections.forEach(sec => {
-            const opt = document.createElement('option');
-            opt.value = sec.id;
-            opt.textContent = sec.name;
-            modalHomeSectionSelect.appendChild(opt);
-        });
-        modalHomeSectionSelect.value = item.homeSectionId;
-
-        modalShopSectionSelect.innerHTML = '';
-        currentList.shopSections.forEach(sec => {
-            const opt = document.createElement('option');
-            opt.value = sec.id;
-            opt.textContent = sec.name;
-            modalShopSectionSelect.appendChild(opt);
-        });
-        modalShopSectionSelect.value = item.shopSectionId;
-
-        showModal('Edit Item', item.text, false, null, null, (newName) => {
-            if (newName && newName.trim() !== '') {
-                const trimmedNewName = newName.trim();
-                const existing = currentList.items.find(i => i.text.trim() === trimmedNewName && i.id !== item.id);
-                if (existing) {
-                    item.wantCount = existing.wantCount;
-                }
-                item.text = trimmedNewName;
-                item.homeSectionId = modalHomeSectionSelect.value;
-                item.shopSectionId = modalShopSectionSelect.value;
-                saveAppState();
-                renderList();
-            }
-        }, () => deleteItem(id));
-
-        modalHomeSectionGroup.classList.remove('hidden');
-        modalShopSectionGroup.classList.remove('hidden');
     }
 
     function addSection(name, isHome) {

--- a/public/index.html
+++ b/public/index.html
@@ -122,16 +122,6 @@
                 </div>
             </div>
 
-            <div class="form-group hidden" id="modal-home-section-group">
-                <label for="modal-home-section" class="modal-label">Home Section</label>
-                <select id="modal-home-section" class="modal-select"></select>
-            </div>
-
-            <div class="form-group hidden" id="modal-shop-section-group">
-                <label for="modal-shop-section" class="modal-label">Shop Section</label>
-                <select id="modal-shop-section" class="modal-select"></select>
-            </div>
-
             <div class="modal-actions">
                 <button id="modal-delete-btn" class="modal-btn delete"
                     style="margin-right: auto; display: none;">Delete</button>


### PR DESCRIPTION
🎯 **What:** Removed the unused `renameItem` function and its exclusively related DOM references (`modal-home-section-group`, `modal-shop-section-group`).
💡 **Why:** This function was dead code, and the specific HTML form groups in the modal were only ever used by it. Removing them improves maintainability, reduces file size, and eliminates unused DOM elements.
✅ **Verification:** Verified by inspecting the code via grep searches to confirm no dependencies existed on this function or the specific DOM variables/HTML tags. Also successfully ran the Playwright test suite (`npx playwright test`) containing 16 tests to guarantee no functionality regressions occurred.
✨ **Result:** A cleaner codebase with fewer dead functions and unused UI components.

---
*PR created automatically by Jules for task [11378358846972655940](https://jules.google.com/task/11378358846972655940) started by @camyoung1234*