### PR TITLE
Remove Sync Conflict Modal

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -392,12 +392,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     const syncMessageDiv = document.getElementById('sync-message');
     const syncIcon = document.getElementById('sync-icon');
 
-    // Conflict Modal Elements
-    const conflictModalOverlay = document.getElementById('conflict-modal-overlay');
-    const localSummaryDiv = document.getElementById('local-summary');
-    const cloudSummaryDiv = document.getElementById('cloud-summary');
-    const keepLocalBtn = document.getElementById('keep-local-btn');
-    const keepCloudBtn = document.getElementById('keep-cloud-btn');
 
     // --- Helpers ---
     const applyManualSelection = (input) => {
@@ -1387,16 +1381,22 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const remoteState = docSnap.data();
                 if (firstSync) {
                     firstSync = false;
-                    // Check for conflict on login
-                    const localHasItems = appState.lists && appState.lists.some(l => l.items && l.items.length > 0);
                     const cloudHasItems = remoteState.lists && remoteState.lists.some(l => l.items && l.items.length > 0);
-                    const dataChanged = JSON.stringify(remoteState.lists) !== JSON.stringify(appState.lists);
+                    const localHasItems = appState.lists && appState.lists.some(l => l.items && l.items.length > 0);
 
-                    if (localHasItems && cloudHasItems && dataChanged && remoteState.updatedAt !== appState.updatedAt) {
-                        if (!window.__MOCK_FIREBASE_STATE__) { // Skip in tests to avoid overlap
-                            showConflictModal(appState, remoteState);
-                            return;
-                        }
+                    if (cloudHasItems) {
+                        // Cloud version of data should be used
+                        appState = remoteState;
+                        currentMode = remoteState.mode || 'home';
+                        editMode = remoteState.editMode !== undefined ? remoteState.editMode : true;
+                        renderListsMenu();
+                        updateModeUI();
+                        renderList();
+                        return;
+                    } else if (localHasItems) {
+                        // Cloud exists but is empty, push local data
+                        saveAppState(true);
+                        return;
                     }
                 }
 
@@ -1410,37 +1410,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                 }
             } else if (firstSync) {
                 firstSync = false;
-                // Cloud is empty, push local data if any
+                // Cloud document doesn't exist, push local data if any
                 saveAppState(true);
             }
         });
-    }
-
-    function showConflictModal(localState, cloudState) {
-        const getSummary = (state) => {
-            if (!state || !state.lists) return 'No data';
-            return state.lists.map(l => `${l.name} (${l.items ? l.items.length : 0} items)`).join('<br>');
-        };
-
-        localSummaryDiv.innerHTML = getSummary(localState);
-        cloudSummaryDiv.innerHTML = getSummary(cloudState);
-
-        conflictModalOverlay.classList.add('visible');
-
-        keepLocalBtn.onclick = () => {
-            saveAppState(true); // Forces local timestamp bump and upload
-            conflictModalOverlay.classList.remove('visible');
-        };
-
-        keepCloudBtn.onclick = () => {
-            appState = cloudState;
-            currentMode = cloudState.mode || 'home';
-            editMode = cloudState.editMode !== undefined ? cloudState.editMode : true;
-            conflictModalOverlay.classList.remove('visible');
-            renderListsMenu();
-            updateModeUI();
-            renderList();
-        };
     }
 
     // --- List Management ---

--- a/public/index.html
+++ b/public/index.html
@@ -189,30 +189,6 @@
         </div>
     </div>
 
-    <!-- Conflict Resolution Modal -->
-    <div id="conflict-modal-overlay" class="modal-overlay">
-        <div class="modal" style="max-width: 400px;">
-            <h3 id="conflict-modal-title">Sync Conflict</h3>
-            <p>Both your device and the cloud have data. Which one would you like to keep?</p>
-
-            <div style="display: flex; gap: 1rem; margin-bottom: 1.5rem;">
-                <div style="flex: 1; padding: 1rem; border: 1px solid var(--border-color); border-radius: 8px;">
-                    <h4 style="margin-top: 0;">Local Device</h4>
-                    <div id="local-summary" style="font-size: 0.85rem; color: var(--text-muted);"></div>
-                </div>
-                <div style="flex: 1; padding: 1rem; border: 1px solid var(--border-color); border-radius: 8px;">
-                    <h4 style="margin-top: 0;">Cloud Storage</h4>
-                    <div id="cloud-summary" style="font-size: 0.85rem; color: var(--text-muted);"></div>
-                </div>
-            </div>
-
-            <div class="modal-actions" style="flex-direction: column; gap: 0.5rem;">
-                <button id="keep-local-btn" class="modal-btn save" style="width: 100%;">Keep Local & Upload</button>
-                <button id="keep-cloud-btn" class="modal-btn save" style="width: 100%;">Keep Cloud & Download</button>
-            </div>
-        </div>
-    </div>
-
     <!-- Restore State Confirmation Modal -->
     <div id="restore-modal-overlay" class="modal-overlay">
         <div class="modal">


### PR DESCRIPTION
I have removed the sync conflict resolution modal as requested. The application now follows a 'cloud-wins' strategy during initial synchronization: if cloud data exists and has items, it overwrites any local data. If the cloud is empty and local data is present, the local data is pushed to the cloud.

Steps taken:
1. Identified and removed the conflict modal HTML structure from `public/index.html`.
2. Cleaned up `public/app.js` by removing now-unused DOM selectors (`conflictModalOverlay`, etc.) and the modal-handling function `showConflictModal`.
3. Modified the `syncWithFirestore` function to implement the new priority logic.
4. Verified that all instances of the removed code were successfully deleted using grep.
5. Attempted frontend verification via Playwright (though environment issues hampered full automated verification, the code changes were manually inspected for correctness).

Fixes #275

---
*PR created automatically by Jules for task [3718726805153565372](https://jules.google.com/task/3718726805153565372) started by @camyoung1234*