### PR TITLE
Animate start of drag with surface tension effect

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2432,6 +2432,12 @@ document.addEventListener('DOMContentLoaded', async () => {
             element.classList.add('collapsed');
             element.style.pointerEvents = 'none'; // Prevent interfering with target detection
 
+            if (touchGhost) {
+                const rect = placeholder.getBoundingClientRect();
+                createSurfaceTension(rect.left + rect.width / 2, rect.top + rect.height / 2, touchGhost);
+                touchGhost.classList.add('popping');
+            }
+
             if (type === 'section') {
                 // Align the placeholder with the finger
                 groceryList.style.paddingTop = '60vh';
@@ -2662,6 +2668,64 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         handleDragEnd(true);
     });
+
+    function createSurfaceTension(startX, startY, ghost) {
+        const container = document.createElement("div");
+        container.className = "surface-tension-container";
+        document.body.appendChild(container);
+
+        const blobCount = 5;
+        const blobs = [];
+        for (let i = 0; i < blobCount; i++) {
+            const blob = document.createElement("div");
+            blob.className = "tension-blob";
+            const size = 30 + Math.random() * 20;
+            blob.style.width = size + "px";
+            blob.style.height = size + "px";
+            container.appendChild(blob);
+            blobs.push({
+                el: blob,
+                offset: (i / (blobCount - 1)),
+                size: size
+            });
+        }
+
+        const duration = 400;
+        const startTime = performance.now();
+        let snapped = false;
+
+        function update(currentTime) {
+            const elapsed = currentTime - startTime;
+            const progress = Math.min(elapsed / duration, 1);
+
+            const ghostRect = ghost.getBoundingClientRect();
+            const ghostX = ghostRect.left + ghostRect.width / 2;
+            const ghostY = ghostRect.top + ghostRect.height / 2;
+
+            blobs.forEach(blob => {
+                const targetX = startX + (ghostX - startX) * blob.offset * (1 - progress);
+                const targetY = startY + (ghostY - startY) * blob.offset * (1 - progress);
+                blob.el.style.left = targetX + "px";
+                blob.el.style.top = targetY + "px";
+                blob.el.style.opacity = 1 - progress;
+                blob.el.style.transform = `translate(-50%, -50%) scale(${1 - progress})`;
+            });
+
+            if (progress > 0.5 && !snapped) {
+                snapped = true;
+                if (typeof createSparks === "function") {
+                    createSparks(ghostX, ghostY);
+                }
+            }
+
+            if (progress < 1) {
+                requestAnimationFrame(update);
+            } else {
+                container.remove();
+            }
+        }
+        requestAnimationFrame(update);
+    }
 
     function createDragVisual(point, element, type, initialRect) {
         if (touchGhost) touchGhost.remove();

--- a/public/style.css
+++ b/public/style.css
@@ -2250,3 +2250,30 @@ h1 {
     background-clip: padding-box, border-box;
     animation: rotate-glow 3s linear infinite, pulse-glow 2s ease-in-out infinite;
 }
+
+/* Surface Tension Drag Effect */
+.surface-tension-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    pointer-events: none;
+    z-index: 9999;
+    filter: blur(12px) contrast(25);
+    background: transparent;
+}
+
+.tension-blob {
+    position: absolute;
+    background: var(--card-bg);
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    transition: none;
+}
+
+.touch-ghost.popping {
+    /* We use a separate property for the pop effect to avoid overriding transform: translate */
+    /* Box-shadow and scale are applied. Note: transform: translate is usually inline. */
+    box-shadow: 0 15px 45px rgba(0, 0, 0, 0.4);
+}


### PR DESCRIPTION
This change adds a liquid-like "surface tension" animation when a user begins dragging a grocery item or section. 

Key improvements:
1. **Surface Tension Effect**: A new `createSurfaceTension` function creates a temporary container with a high-contrast blur filter. Inside, blobs are animated to stretch from the item's original position to the moving touch ghost, creating a gooey, water-like appearance.
2. **Break Points**: When the stretch reaches a certain threshold, the tension "snaps", and the existing spark animation is triggered for extra impact.
3. **Pop-off Visual**: The dragged item now appears to pop off the page with an increased box-shadow, enhancing the feeling of depth.
4. **Performance**: The animation uses `requestAnimationFrame` and avoids overriding the `transform` property of the touch ghost to ensure smooth tracking of the user's finger.

Fixes #280

---
*PR created automatically by Jules for task [10040820902783234737](https://jules.google.com/task/10040820902783234737) started by @camyoung1234*