### PR TITLE
⚡ Fix layout thrashing in animatePlaceholderMove

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2486,8 +2486,14 @@ document.addEventListener('DOMContentLoaded', async () => {
             target.after(placeholder);
         }
 
+        // Batch reads before writes to avoid layout thrashing
+        const newPositions = new Map();
         relevantSiblings.forEach(el => {
-            const newTop = el.getBoundingClientRect().top;
+            newPositions.set(el, el.getBoundingClientRect().top);
+        });
+
+        relevantSiblings.forEach(el => {
+            const newTop = newPositions.get(el);
             const oldTop = initialPositions.get(el);
             const delta = oldTop - newTop;
 


### PR DESCRIPTION
Fix layout thrashing in animation loop. The code caused layout thrashing during animation frames by mixing read/write operations (getBoundingClientRect inside a loop). Fixed by batching reads before writes.

---
*PR created automatically by Jules for task [7202527230101893615](https://jules.google.com/task/7202527230101893615) started by @camyoung1234*