### PR TITLE
Prevent page jump when keyboard opens on Chrome for Android

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2398,6 +2398,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (draggedElement !== element) return;
             
             isDragStarted = true;
+            document.documentElement.classList.add('is-dragging');
             groceryList.classList.add('no-transition');
             document.body.style.overflow = 'hidden';
 
@@ -2795,6 +2796,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 saveAppState();
             }
 
+            document.documentElement.classList.remove('is-dragging');
+
             // Capture headers one last time before clearing padding/DRAG state
             let headerFinalDragTops = new Map();
             if (type === 'section') {
@@ -2965,6 +2968,37 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
             newSectionItems.forEach((item, idx) => { item[indexKey] = idx; });
         }
+    }
+
+    // --- Keyboard Jump Prevention ---
+    // Smoothly scroll to inputs when they are focused to prevent the native "jump"
+    document.addEventListener('focusin', (e) => {
+        const t = e.target;
+        if (t.tagName === 'INPUT' && (t.classList.contains('inline-item-input') || t.classList.contains('qty-input') || t.classList.contains('inline-edit-input') || t.classList.contains('inline-section-input'))) {
+            // Use a small timeout to let the virtual keyboard start appearing
+            // and the browser's native scroll-into-view to trigger first
+            setTimeout(() => {
+                t.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            }, 150);
+        }
+    });
+
+    // When the keyboard closes, maintain the scroll position if an input is still focused
+    if (window.visualViewport) {
+        let lastViewportHeight = window.visualViewport.height;
+        window.visualViewport.addEventListener('resize', () => {
+            const currentViewportHeight = window.visualViewport.height;
+            const isClosing = currentViewportHeight > lastViewportHeight;
+
+            if (isClosing && document.activeElement && document.activeElement.tagName === 'INPUT') {
+                const currentScroll = window.scrollY;
+                // Use requestAnimationFrame to ensure we run after the browser's attempt to "jump back"
+                requestAnimationFrame(() => {
+                    window.scrollTo({ top: currentScroll, behavior: 'auto' });
+                });
+            }
+            lastViewportHeight = currentViewportHeight;
+        });
     }
 
     init();

--- a/public/style.css
+++ b/public/style.css
@@ -2,6 +2,14 @@
     box-sizing: border-box;
 }
 
+html {
+    scroll-behavior: smooth;
+}
+
+html.is-dragging {
+    scroll-behavior: auto !important;
+}
+
 :root {
     /* Theme Colors (Light Mode) - Material 500 */
     --theme-red: #f44336;


### PR DESCRIPTION
This change addresses the jarring page jumps experienced on Chrome for Android when the virtual keyboard opens or closes. 

Key improvements:
1. **Smooth Entrance**: Instead of a sudden jump, the page now smoothly scrolls to center the focused input field.
2. **Stable Dismissal**: By monitoring the `visualViewport`, the application now detects when the keyboard closes and proactively maintains the current scroll position, overriding the browser's default behavior of jumping back to the pre-focus position.
3. **Drag-and-Drop Safety**: A new `.is-dragging` state on the root element ensures that the global smooth scrolling does not interfere with the high-frequency scroll updates required during item reordering.

Verified via automated Playwright tests and visual recording.

Fixes #285

---
*PR created automatically by Jules for task [12080436399462531731](https://jules.google.com/task/12080436399462531731) started by @camyoung1234*