### PR TITLE
Fix X button offset alignment

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -2183,7 +2183,7 @@ h1 {
 
 .item-delete-btn {
     position: absolute;
-    right: 0.5rem;
+    right: 1rem;
     width: 48px;
     min-width: 48px;
     transition: opacity 0.3s ease, visibility 0.3s ease;


### PR DESCRIPTION
The delete button (`.item-delete-btn`) was previously offset by `0.5rem` from the right edge, while the quantity controls it replaces were aligned with the container's `1rem` right padding. This caused a horizontal misalignment when switching between view and edit modes.

I updated the CSS to use `right: 1rem` for the delete button, which Playwright measurements confirmed achieves perfect center-to-center alignment (0px difference). I also verified the visual change with a screenshot.

Fixes #292

---
*PR created automatically by Jules for task [12650141505886834979](https://jules.google.com/task/12650141505886834979) started by @camyoung1234*