### PR TITLE
Frosted glass drag effect

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2721,6 +2721,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         touchGhost = element.cloneNode(true);
         touchGhost.classList.add('touch-ghost');
+        touchGhost.classList.add('popping');
         touchGhost.classList.remove('dragging', 'collapsed');
 
         // Add current mode class to the ghost so mode-specific styles apply

--- a/public/style.css
+++ b/public/style.css
@@ -2148,7 +2148,7 @@ h1 {
     pointer-events: none;
     z-index: 10000;
     opacity: 1;
-    background: color-mix(in srgb, var(--card-bg) 70%, transparent);
+    background: color-mix(in srgb, var(--card-bg) 40%, transparent) !important;
     backdrop-filter: blur(20px) saturate(180%);
     -webkit-backdrop-filter: blur(20px) saturate(180%);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
@@ -2165,7 +2165,12 @@ h1 {
     transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.2s ease;
 }
 
-.touch-ghost * {
+.touch-ghost *,
+.touch-ghost .grocery-item,
+.touch-ghost .section-header,
+.touch-ghost .item-info,
+.touch-ghost .quantity-controls {
+    background: transparent !important;
     transition: none !important;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -2148,12 +2148,21 @@ h1 {
     pointer-events: none;
     z-index: 10000;
     opacity: 1;
-    background: var(--card-bg);
+    background: color-mix(in srgb, var(--card-bg) 70%, transparent);
+    backdrop-filter: blur(20px) saturate(180%);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
     border-radius: var(--border-radius);
+    border: 1px solid rgba(255, 255, 255, 0.2);
     overflow: hidden;
     transform: scale(1.02);
     /* Ensure styles like borders from .grocery-item or .section-container are preserved if cloned */
+}
+
+.touch-ghost.popping {
+    transform: scale(1.05);
+    box-shadow: 0 15px 45px rgba(0, 0, 0, 0.4);
+    transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.2s ease;
 }
 
 .touch-ghost * {


### PR DESCRIPTION
The drag-and-drop experience has been enhanced with a modern "frosted glass" effect for the dragged item ghost. 

Changes include:
- **Frosted Glass Aesthetic:** The `.touch-ghost` now uses `backdrop-filter: blur(20px) saturate(180%)` and a semi-transparent background, allowing underlying items to be visible but blurred, mimicking the iOS "liquid glass" style.
- **Improved Visual Feedback:** A new `.popping` class is added to the ghost on creation, triggering a smooth scale-up and an increased shadow to simulate the item lifting off the page.
- **Refined Styling:** A subtle semi-transparent border was added to the ghost to define its edges against various backgrounds.

These changes were verified visually via Playwright screenshots and videos, and regression testing was performed to ensure core functionality remains intact.

Fixes #294

---
*PR created automatically by Jules for task [6251855181275656501](https://jules.google.com/task/6251855181275656501) started by @camyoung1234*