### PR TITLE
Increase Layout Density

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2728,7 +2728,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         // Lock width and height
         touchGhost.style.width = element.offsetWidth + 'px';
-        touchGhost.style.height = (type === 'section' ? 50 : element.offsetHeight) + 'px';
+        touchGhost.style.height = (type === 'section' ? 40 : element.offsetHeight) + 'px';
 
         // Lock horizontal position based on the original element's rect
         touchGhost.style.left = rect.left + 'px';

--- a/public/style.css
+++ b/public/style.css
@@ -462,7 +462,7 @@ h1 {
     align-items: center;
     justify-content: space-between;
     padding: 0 1rem 0 0.5rem;
-    height: 50px;
+    height: 40px;
     box-sizing: border-box;
     background: transparent;
     transition: var(--transition);
@@ -547,7 +547,7 @@ h1 {
 
 .section-container .grocery-item.shop-chip {
     padding: 0 1rem 0 0.5rem;
-    height: 50px;
+    height: 40px;
     background: transparent;
     border-radius: 0;
     width: 100%;
@@ -1400,7 +1400,7 @@ h1 {
     border-bottom: none;
     padding: 0 1rem 0 0.5rem;
     margin-bottom: 0;
-    height: 50px;
+    height: 40px;
     user-select: none;
 }
 
@@ -1449,7 +1449,7 @@ h1 {
     align-items: center;
     justify-content: center;
     width: 0;
-    height: 50px;
+    height: 40px;
     position: relative;
     overflow: visible;
     transition: width 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), margin-left 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
@@ -1476,7 +1476,7 @@ h1 {
     pointer-events: none;
     margin: 0 !important;
     width: 48px !important;
-    height: 50px !important;
+    height: 40px !important;
     display: flex !important;
     align-items: center !important;
     justify-content: center !important;
@@ -1539,14 +1539,14 @@ h1 {
 
 .section-container .grocery-item {
     padding: 0 1rem 0 0.5rem;
-    height: 50px;
+    height: 40px;
     box-sizing: border-box;
     border-radius: 0;
 }
 
 .section-container .add-item-row {
     padding: 0 1rem 0 0.5rem;
-    height: 50px;
+    height: 40px;
     box-sizing: border-box;
     display: flex;
     align-items: center;
@@ -1572,7 +1572,7 @@ h1 {
     background: color-mix(in srgb, var(--primary-color) 15%, transparent) !important;
     border-radius: 12px;
     padding: 0 1rem 0 0.5rem;
-    height: 50px !important;
+    height: 40px !important;
     box-sizing: border-box;
     margin-bottom: 0;
     cursor: default;
@@ -1607,7 +1607,7 @@ h1 {
 }
 
 .section-container .grocery-item.undo-row {
-    height: 50px;
+    height: 40px;
 }
 
 .grocery-item.undo-row .item-info {
@@ -1975,8 +1975,8 @@ h1 {
 
 .home-mode.hide-drag-handles .add-item-row,
 .home-mode.hide-drag-handles .add-section-row {
-    height: 50px;
-    max-height: 50px;
+    height: 40px;
+    max-height: 40px;
     opacity: 0;
 }
 
@@ -1986,7 +1986,7 @@ h1 {
 
 .left-action {
     width: 40px;
-    height: 50px;
+    height: 40px;
     position: relative;
     display: flex;
     align-items: center;
@@ -2024,7 +2024,7 @@ h1 {
 /* Drag and Drop Styles */
 .drag-handle {
     width: 40px;
-    height: 50px;
+    height: 40px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -2096,8 +2096,8 @@ h1 {
 .add-section-row,
 .grocery-item,
 .section-header {
-    height: 50px;
-    max-height: 50px;
+    height: 40px;
+    max-height: 40px;
     overflow: hidden;
     transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
     flex-wrap: nowrap !important;
@@ -2172,7 +2172,7 @@ h1 {
     color: var(--text-muted);
     font-size: 1.2rem;
     cursor: pointer;
-    height: 50px;
+    height: 40px;
     align-items: center;
     justify-content: center;
     opacity: 0;
@@ -2322,8 +2322,8 @@ h1 {
 
 .is-dragging .add-item-row,
 .is-dragging .add-section-row {
-    height: 50px !important;
-    max-height: 50px !important;
+    height: 40px !important;
+    max-height: 40px !important;
     opacity: 0.3 !important;
     pointer-events: auto !important;
 }
@@ -2370,7 +2370,7 @@ h1 {
 
 .drag-placeholder.active-ph {
     display: block !important;
-    height: 50px !important;
+    height: 40px !important;
     margin: 0 !important;
     background: color-mix(in srgb, var(--primary-color) 10%, var(--hover-bg)) !important;
     border: 2px dashed var(--primary-color) !important;


### PR DESCRIPTION
Reduced the vertical footprint of list items and headers from 50px to 40px to fit more content on the screen. This was achieved by updating CSS height/max-height properties and synchronized JavaScript drag-and-drop height logic. Verified with E2E tests and visual inspection.

Fixes #291

---
*PR created automatically by Jules for task [4745279315695036731](https://jules.google.com/task/4745279315695036731) started by @camyoung1234*