### PR TITLE
Fix Drag Target Bug and Improve Mobile Layout

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2598,7 +2598,14 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (!draggedElement) return;
 
             let targetSelector = dragType === 'section' ? '.section-container, .add-section-row' : '.grocery-item, .section-header, .add-item-row, .add-section-row';
-            let target = e.target.closest(targetSelector);
+
+            // For desktop dragover, ALWAYS use center point for target detection to match touch behavior
+            // and solve edge/gutter glitches.
+            const listRect = groceryList.getBoundingClientRect();
+            const centerX = listRect.left + listRect.width / 2;
+            const viewportY = Math.max(0, Math.min(window.innerHeight - 1, e.clientY));
+            const elAtCenter = document.elementFromPoint(centerX, viewportY);
+            let target = elAtCenter ? elAtCenter.closest(targetSelector) : null;
 
             if (!target || target === draggedElement || target.classList.contains('drag-placeholder')) return;
 
@@ -2765,7 +2772,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             draggedElement.style.pointerEvents = 'none';
             if (touchGhost) touchGhost.style.pointerEvents = 'none';
 
-            let target = document.elementFromPoint(touch.clientX, touch.clientY);
+            const listRect = groceryList.getBoundingClientRect();
+            const centerX = listRect.left + listRect.width / 2;
+            let target = document.elementFromPoint(centerX, touch.clientY);
 
             draggedElement.style.pointerEvents = originalPointerEvents;
             if (touchGhost) touchGhost.style.pointerEvents = '';

--- a/public/style.css
+++ b/public/style.css
@@ -128,7 +128,7 @@ body {
     width: 100%;
     max-width: 500px;
     background: var(--card-bg);
-    padding: 1rem 1rem 0 1rem;
+    padding: 1rem 0 0 0;
     /* 1rem gutter for symmetry and to avoid mobile back gestures, bottom removed */
     box-shadow: var(--shadow);
     display: flex;
@@ -154,7 +154,7 @@ header {
     justify-content: center;
     align-items: center;
     margin-bottom: 2rem;
-    padding: 0;
+    padding: 0 1rem;
     /* Restore horizontal padding */
 }
 

--- a/tests/repro_bug.test.js
+++ b/tests/repro_bug.test.js
@@ -1,69 +1,58 @@
-const { mockFirebase, setMockState } = require('./mockFirebase');
 const { test, expect } = require('@playwright/test');
+const { mockFirebase, setMockState } = require('./mockFirebase');
 
-test('reproduce drag target glitch at far left', async ({ page }) => {
-  await page.goto('http://localhost:3000');
-  await page.setViewportSize({ width: 375, height: 667 });
+test('Clicking on item name in Shop mode toggles completion', async ({ page }) => {
+  await mockFirebase(page);
+  await page.addInitScript(() => { localStorage.setItem('grocery-logged-in', 'true'); });
+    await page.goto('http://localhost:3000#');
 
-  // Setup state with several items
-  const listId = 'list-1';
+  // Seed state: One item, Shop mode, Edit mode OFF
+  const listId = Date.now().toString();
   const state = {
     lists: [{
       id: listId,
       name: 'Test List',
       theme: 'var(--theme-blue)',
-      homeSections: [{ id: 'sec-h-1', name: 'Section 1' }],
-      shopSections: [{ id: 'sec-s-def', name: 'Uncategorized' }],
-      items: [
-        { id: 'item-1', text: 'Item 1', homeSectionId: 'sec-h-1', shopSectionId: 'sec-s-def', homeIndex: 0, shopIndex: 0, haveCount: 0, wantCount: 1, shopCompleted: false },
-        { id: 'item-2', text: 'Item 2', homeSectionId: 'sec-h-1', shopSectionId: 'sec-s-def', homeIndex: 1, shopIndex: 1, haveCount: 0, wantCount: 1, shopCompleted: false },
-        { id: 'item-3', text: 'Item 3', homeSectionId: 'sec-h-1', shopSectionId: 'sec-s-def', homeIndex: 2, shopIndex: 2, haveCount: 0, wantCount: 1, shopCompleted: false }
-      ]
+      homeSections: [{ id: 'sec-h-1', name: 'Home Section' }],
+      shopSections: [{ id: 'sec-s-1', name: 'Shop Section' }],
+      items: [{
+          id: 'item-1',
+          text: 'Test Item',
+          homeSectionId: 'sec-h-1',
+          shopSectionId: 'sec-s-1',
+          homeIndex: 0,
+          shopIndex: 0,
+          haveCount: 0,
+          wantCount: 1,
+          shopCompleted: false
+      }]
     }],
-    currentListId: listId
+    currentListId: listId,
+    mode: 'shop',
+    editMode: false
   };
-  await setMockState(page, { ...state, mode: 'home', editMode: true });
+  await setMockState(page, state);
 
-  await page.waitForSelector('.grocery-item[data-id="item-1"]');
+  // If restore modal is visible, click cancel
+  const cancelBtn = page.locator('#restore-cancel-btn');
+  if (await cancelBtn.isVisible()) {
+      await cancelBtn.click();
+  }
 
-  const item1 = page.locator('.grocery-item[data-id="item-1"]');
-  const item3 = page.locator('.grocery-item[data-id="item-3"]');
+  // Ensure we are in Shop mode
+  await expect(page.locator('#toolbar-mode')).toHaveClass(/active/);
 
-  const handle1 = item1.locator('.drag-handle');
-  const box1 = await handle1.boundingBox();
-  const box3 = await item3.boundingBox();
+  const itemText = page.locator('.grocery-item.shop-chip .item-text');
+  await expect(itemText).toHaveText('Test Item');
 
-  // Start drag on item 1 handle
-  await page.mouse.move(box1.x + box1.width / 2, box1.y + box1.height / 2);
-  await page.mouse.down();
+  // Check that it's NOT completed
+  const itemRow = page.locator('.grocery-item.shop-chip');
+  await expect(itemRow).not.toHaveClass(/completed/);
 
-  // Move slightly to trigger drag start
-  await page.mouse.move(box1.x + box1.width / 2, box1.y + box1.height / 2 + 10);
+  // Click on the item name
+  await itemText.click();
 
-  // Wait for placeholder to appear
-  await expect(page.locator('.drag-placeholder')).toBeVisible();
-
-  // Now move to the far left (x=2), but at the Y of item 3
-  await page.mouse.move(2, box3.y + box3.height / 2);
-
-  // In a glitchy scenario, the placeholder will NOT move to item 3's position
-  // because document.elementFromPoint(2, y) won't hit an item.
-
-  // Wait a bit for any RAF to fire
-  await page.waitForTimeout(200);
-
-  // Check placeholder position. It should be near item 3.
-  // We can check the sibling of the placeholder.
-  const placeholder = page.locator('.drag-placeholder');
-
-  // If it's still before item 1, it didn't move.
-  // We expect it to be near item 3 (either before or after it).
-
-  const phBox = await placeholder.boundingBox();
-  console.log(`Placeholder Y: ${phBox.y}, Item 3 Y: ${box3.y}`);
-
-  // If glitching, phBox.y should be near box1.y (approx 66px from top usually)
-  // item 3 is at approx 66 + 50 + 50 = 166.
-
-  expect(phBox.y).toBeGreaterThan(box3.y - 50);
+  // It should become completed (after animation)
+  // The toggleShopCompleted has some timeouts, so we might need to wait
+  await expect(itemRow).toHaveClass(/completed/, { timeout: 5000 });
 });

--- a/tests/repro_bug.test.js
+++ b/tests/repro_bug.test.js
@@ -1,58 +1,69 @@
-const { test, expect } = require('@playwright/test');
 const { mockFirebase, setMockState } = require('./mockFirebase');
+const { test, expect } = require('@playwright/test');
 
-test('Clicking on item name in Shop mode toggles completion', async ({ page }) => {
-  await mockFirebase(page);
-  await page.addInitScript(() => { localStorage.setItem('grocery-logged-in', 'true'); });
-    await page.goto('http://localhost:3000#');
+test('reproduce drag target glitch at far left', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  await page.setViewportSize({ width: 375, height: 667 });
 
-  // Seed state: One item, Shop mode, Edit mode OFF
-  const listId = Date.now().toString();
+  // Setup state with several items
+  const listId = 'list-1';
   const state = {
     lists: [{
       id: listId,
       name: 'Test List',
       theme: 'var(--theme-blue)',
-      homeSections: [{ id: 'sec-h-1', name: 'Home Section' }],
-      shopSections: [{ id: 'sec-s-1', name: 'Shop Section' }],
-      items: [{
-          id: 'item-1',
-          text: 'Test Item',
-          homeSectionId: 'sec-h-1',
-          shopSectionId: 'sec-s-1',
-          homeIndex: 0,
-          shopIndex: 0,
-          haveCount: 0,
-          wantCount: 1,
-          shopCompleted: false
-      }]
+      homeSections: [{ id: 'sec-h-1', name: 'Section 1' }],
+      shopSections: [{ id: 'sec-s-def', name: 'Uncategorized' }],
+      items: [
+        { id: 'item-1', text: 'Item 1', homeSectionId: 'sec-h-1', shopSectionId: 'sec-s-def', homeIndex: 0, shopIndex: 0, haveCount: 0, wantCount: 1, shopCompleted: false },
+        { id: 'item-2', text: 'Item 2', homeSectionId: 'sec-h-1', shopSectionId: 'sec-s-def', homeIndex: 1, shopIndex: 1, haveCount: 0, wantCount: 1, shopCompleted: false },
+        { id: 'item-3', text: 'Item 3', homeSectionId: 'sec-h-1', shopSectionId: 'sec-s-def', homeIndex: 2, shopIndex: 2, haveCount: 0, wantCount: 1, shopCompleted: false }
+      ]
     }],
-    currentListId: listId,
-    mode: 'shop',
-    editMode: false
+    currentListId: listId
   };
-  await setMockState(page, state);
+  await setMockState(page, { ...state, mode: 'home', editMode: true });
 
-  // If restore modal is visible, click cancel
-  const cancelBtn = page.locator('#restore-cancel-btn');
-  if (await cancelBtn.isVisible()) {
-      await cancelBtn.click();
-  }
+  await page.waitForSelector('.grocery-item[data-id="item-1"]');
 
-  // Ensure we are in Shop mode
-  await expect(page.locator('#toolbar-mode')).toHaveClass(/active/);
+  const item1 = page.locator('.grocery-item[data-id="item-1"]');
+  const item3 = page.locator('.grocery-item[data-id="item-3"]');
 
-  const itemText = page.locator('.grocery-item.shop-chip .item-text');
-  await expect(itemText).toHaveText('Test Item');
+  const handle1 = item1.locator('.drag-handle');
+  const box1 = await handle1.boundingBox();
+  const box3 = await item3.boundingBox();
 
-  // Check that it's NOT completed
-  const itemRow = page.locator('.grocery-item.shop-chip');
-  await expect(itemRow).not.toHaveClass(/completed/);
+  // Start drag on item 1 handle
+  await page.mouse.move(box1.x + box1.width / 2, box1.y + box1.height / 2);
+  await page.mouse.down();
 
-  // Click on the item name
-  await itemText.click();
+  // Move slightly to trigger drag start
+  await page.mouse.move(box1.x + box1.width / 2, box1.y + box1.height / 2 + 10);
 
-  // It should become completed (after animation)
-  // The toggleShopCompleted has some timeouts, so we might need to wait
-  await expect(itemRow).toHaveClass(/completed/, { timeout: 5000 });
+  // Wait for placeholder to appear
+  await expect(page.locator('.drag-placeholder')).toBeVisible();
+
+  // Now move to the far left (x=2), but at the Y of item 3
+  await page.mouse.move(2, box3.y + box3.height / 2);
+
+  // In a glitchy scenario, the placeholder will NOT move to item 3's position
+  // because document.elementFromPoint(2, y) won't hit an item.
+
+  // Wait a bit for any RAF to fire
+  await page.waitForTimeout(200);
+
+  // Check placeholder position. It should be near item 3.
+  // We can check the sibling of the placeholder.
+  const placeholder = page.locator('.drag-placeholder');
+
+  // If it's still before item 1, it didn't move.
+  // We expect it to be near item 3 (either before or after it).
+
+  const phBox = await placeholder.boundingBox();
+  console.log(`Placeholder Y: ${phBox.y}, Item 3 Y: ${box3.y}`);
+
+  // If glitching, phBox.y should be near box1.y (approx 66px from top usually)
+  // item 3 is at approx 66 + 50 + 50 = 166.
+
+  expect(phBox.y).toBeGreaterThan(box3.y - 50);
 });


### PR DESCRIPTION
Fixed a bug where dragging items over the far left side of the screen caused the drag placeholder to disappear. This was achieved by implementing a robust targeting fallback in `public/app.js` that uses the horizontal center of the list for target detection. Additionally, updated `public/style.css` to support an edge-to-edge layout on mobile devices, which improves the visual consistency of the app.

Fixes #293

---
*PR created automatically by Jules for task [366731862218427840](https://jules.google.com/task/366731862218427840) started by @camyoung1234*