### PR TITLE
New Floating Add Item Flow

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -59,6 +59,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const shopDefId = 'sec-s-def'; // Default Uncategorized ID for Shop Mode
     let selectionRenderTimeout = null;
     let unsubscribeFirestore = null;
+    let floatingAddItemRow = null;
 
     // --- DOM Elements ---
     const groceryList = document.getElementById('grocery-list');
@@ -341,6 +342,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Toolbar Elements
     const toolbarSyncBtn = document.getElementById('toolbar-sync');
+    const toolbarAddItemBtn = document.getElementById('toolbar-add-item');
     const toolbarListsBtn = document.getElementById('toolbar-lists');
     const currentListSwatch = document.getElementById('current-list-swatch');
     const toolbarModeBtn = document.getElementById('toolbar-mode');
@@ -730,6 +732,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     // --- Toolbar Interactions ---
+    if (toolbarAddItemBtn) {
+        toolbarAddItemBtn.addEventListener('click', () => {
+            showFloatingAddItem();
+        });
+    }
+
     if (toolbarSyncBtn) {
         toolbarSyncBtn.addEventListener('click', () => {
             if (syncErrorDiv) {
@@ -1641,6 +1649,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         const newInlineInput = document.querySelector(`.section-items-list[data-section-id="${sectionId}"] .inline-item-input`);
         if (newInlineInput) newInlineInput.focus();
+        return newItem;
     }
 
     function createSparks(x, y) {
@@ -2051,6 +2060,70 @@ document.addEventListener('DOMContentLoaded', async () => {
         return handle;
     }
 
+    function showFloatingAddItem() {
+        if (floatingAddItemRow) {
+            floatingAddItemRow.querySelector('.add-item-input').focus();
+            return;
+        }
+
+        const row = document.createElement('div');
+        row.className = 'grocery-item floating-item-row show-controls';
+        row.innerHTML = `
+            <div class="left-action">
+                <div class="drag-handle" draggable="true"><i class="fas fa-grip-vertical"></i></div>
+            </div>
+            <div class="item-info">
+                <form class="input-group inline-input-group" style="width: 100%;">
+                    <input type="text" class="inline-item-input add-item-input" placeholder="Add item" aria-label="New item name" autocomplete="off">
+                </form>
+            </div>
+        `;
+
+        floatingAddItemRow = row;
+
+        const handle = row.querySelector('.drag-handle');
+        handle.addEventListener('dragstart', (e) => handleDragStart(e, row, 'item'));
+        handle.addEventListener('touchstart', (e) => handleTouchStart(e, row, 'item'), { passive: false });
+
+        const input = row.querySelector('.add-item-input');
+        input.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                const text = input.value.trim();
+                if (text) {
+                    const currentList = getCurrentList();
+                    const firstSectionId = currentList.homeSections[0]?.id || getOrCreateUncategorizedSection(true).id;
+                    addItemToSection(firstSectionId, text, true);
+                }
+                removeFloatingAddItem();
+            } else if (e.key === 'Escape') {
+                removeFloatingAddItem();
+            }
+        });
+
+        // Use a small timeout to avoid immediate removal when clicking the toolbar button
+        setTimeout(() => {
+            const clickOutside = (e) => {
+                if (floatingAddItemRow && !floatingAddItemRow.contains(e.target)) {
+                    removeFloatingAddItem();
+                    document.removeEventListener('click', clickOutside);
+                }
+            };
+            document.addEventListener('click', clickOutside);
+        }, 10);
+
+        appContainer.appendChild(row);
+        applyManualSelection(input);
+        input.focus();
+    }
+
+    function removeFloatingAddItem() {
+        if (floatingAddItemRow) {
+            floatingAddItemRow.remove();
+            floatingAddItemRow = null;
+        }
+    }
+
     function renderList() {
         const fragment = document.createDocumentFragment();
         const currentList = getCurrentList();
@@ -2259,16 +2332,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             });
 
 
-            // Add "Add item" row for this section
-            if (isHome) {
-                const addRow = document.createElement('li');
-                addRow.className = 'grocery-item add-item-row';
-                if (isSectionRestoration) addRow.classList.add('restoring-item');
-                addRow.dataset.type = 'item-placeholder';
-                addRow.dataset.sectionId = section.id;
-                addRow.innerHTML = `<div class="left-action"><button class="drag-handle add-row-plus" type="button" aria-label="Add item to ${escapeHTML(section.name)}"><i class="fas fa-plus" aria-hidden="true"></i></button></div><div class="item-info"><form class="input-group inline-input-group"><input type="text" class="inline-item-input add-item-input" placeholder="Add item" aria-label="New item name for ${escapeHTML(section.name)}" autocomplete="off"></form></div>`;
-                itemsUl.appendChild(addRow);
-            }
             sectionLi.appendChild(itemsUl);
 
             fragment.appendChild(sectionLi);
@@ -2379,7 +2442,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     function handleDragStart(e, element, type) {
-        if (!editMode && !element.classList.contains("show-controls")) {
+        if (!editMode && !element.classList.contains("show-controls") && !element.classList.contains("floating-item-row")) {
             e.preventDefault();
             return;
         }
@@ -2443,7 +2506,11 @@ document.addEventListener('DOMContentLoaded', async () => {
             document.body.style.overflow = 'hidden';
 
             // Initialize placeholder at starting position
-            element.before(placeholder);
+            if (element.classList.contains('floating-item-row')) {
+                groceryList.appendChild(placeholder);
+            } else {
+                element.before(placeholder);
+            }
 
             // Force another reflow to ensure placeholder and siblings are correctly positioned in the parent
             void groceryList.offsetHeight;
@@ -2643,6 +2710,57 @@ document.addEventListener('DOMContentLoaded', async () => {
     groceryList.addEventListener('drop', (e) => {
         e.preventDefault();
         if (!draggedElement) return;
+
+        if (draggedElement.classList.contains('floating-item-row')) {
+            const input = draggedElement.querySelector('.add-item-input');
+            const text = input.value.trim();
+            if (!text) {
+                removeFloatingAddItem();
+                handleDragEnd(false);
+                return;
+            }
+
+            const elements = Array.from(groceryList.children).filter(el =>
+                el === placeholder ||
+                el.classList.contains('section-header') ||
+                (el.classList.contains('grocery-item') && !el.classList.contains('add-item-row'))
+            );
+            const placeholderIdx = elements.indexOf(placeholder);
+
+            let targetSectionId = null;
+            for (let i = placeholderIdx; i >= 0; i--) {
+                if (elements[i].classList.contains('section-header')) {
+                    targetSectionId = elements[i].dataset.originalSectionId;
+                    break;
+                }
+            }
+
+            if (!targetSectionId) {
+                const currentList = getCurrentList();
+                targetSectionId = currentList.homeSections[0]?.id || getOrCreateUncategorizedSection(true).id;
+            }
+
+            let anchorId = null;
+            let isAtEnd = true;
+            for (let i = placeholderIdx + 1; i < elements.length; i++) {
+                const el = elements[i];
+                if (el.classList.contains('section-header')) break;
+                if (el.classList.contains('grocery-item') && !el.classList.contains('add-item-row') && !el.classList.contains('add-section-row')) {
+                    anchorId = el.dataset.id;
+                    isAtEnd = false;
+                    break;
+                }
+            }
+
+            const newItem = addItemToSection(targetSectionId, text, true);
+            if (newItem) {
+                updateOrderInState(newItem.id, anchorId, targetSectionId, isAtEnd);
+            }
+
+            removeFloatingAddItem();
+            handleDragEnd(true);
+            return;
+        }
 
         const isHome = currentMode === 'home';
         const currentList = getCurrentList();

--- a/public/app.js
+++ b/public/app.js
@@ -24,15 +24,18 @@ const SYNC_SLASH_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" 
 // Ensure these are globally accessible for tests if needed
 window.appAuth = auth;
 
+let appState = {
+    lists: [],
+    currentListId: null,
+    mode: 'home',
+    editMode: true,
+    updatedAt: 0
+};
+window.getAppState = () => appState;
+window.setAppState = (s) => { appState = s; };
+
 document.addEventListener('DOMContentLoaded', async () => {
     // --- State ---
-    let appState = {
-        lists: [],
-        currentListId: null,
-        mode: 'home',
-        editMode: true,
-        updatedAt: 0
-    };
 
     let currentMode = 'home'; // 'home' or 'shop'
     let editMode = true;
@@ -60,6 +63,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     let selectionRenderTimeout = null;
     let unsubscribeFirestore = null;
     let floatingAddItemRow = null;
+    let lastDroppedItemId = null;
 
     // --- DOM Elements ---
     const groceryList = document.getElementById('grocery-list');
@@ -2104,11 +2108,23 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Use a small timeout to avoid immediate removal when clicking the toolbar button
         setTimeout(() => {
             const clickOutside = (e) => {
-                if (floatingAddItemRow && !floatingAddItemRow.contains(e.target)) {
+                if (floatingAddItemRow && !floatingAddItemRow.contains(e.target) && !toolbarAddItemBtn.contains(e.target)) {
                     removeFloatingAddItem();
                     document.removeEventListener('click', clickOutside);
                 }
             };
+            // Also remove the listener if the row is removed by other means
+            const observer = new MutationObserver((mutations) => {
+                mutations.forEach((mutation) => {
+                    mutation.removedNodes.forEach((node) => {
+                        if (node === row) {
+                            document.removeEventListener('click', clickOutside);
+                            observer.disconnect();
+                        }
+                    });
+                });
+            });
+            observer.observe(appContainer, { childList: true });
             document.addEventListener('click', clickOutside);
         }, 10);
 
@@ -2359,6 +2375,19 @@ document.addEventListener('DOMContentLoaded', async () => {
         groceryList.querySelectorAll('.add-item-input, .add-section-input').forEach(applyManualSelection);
 
         newlyDeletedIds.clear();
+
+        if (lastDroppedItemId) {
+            const row = groceryList.querySelector(`.grocery-item[data-id="${lastDroppedItemId}"]`);
+            if (row) {
+                const item = currentList.items.find(i => i.id === lastDroppedItemId);
+                const textSpan = row.querySelector('.item-text');
+                const info = row.querySelector('.item-info');
+                if (item && textSpan && info) {
+                    startInlineItemEdit(item, info, textSpan);
+                }
+            }
+            lastDroppedItemId = null;
+        }
     }
 
     function createQtyStepper(item, type) {
@@ -2713,11 +2742,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         if (draggedElement.classList.contains('floating-item-row')) {
             const input = draggedElement.querySelector('.add-item-input');
-            const text = input.value.trim();
+            let text = input.value.trim();
             if (!text) {
-                removeFloatingAddItem();
-                handleDragEnd(false);
-                return;
+                text = "New Item";
             }
 
             const elements = Array.from(groceryList.children).filter(el =>
@@ -2755,6 +2782,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             const newItem = addItemToSection(targetSectionId, text, true);
             if (newItem) {
                 updateOrderInState(newItem.id, anchorId, targetSectionId, isAtEnd);
+                lastDroppedItemId = newItem.id;
             }
 
             removeFloatingAddItem();

--- a/public/index.html
+++ b/public/index.html
@@ -43,6 +43,9 @@
             </div>
 
             <div class="toolbar-actions">
+                <button class="toolbar-btn" id="toolbar-add-item" title="Add Item" aria-label="Add Item">
+                    <i class="fas fa-plus" aria-hidden="true"></i>
+                </button>
                 <button class="toolbar-btn" id="toolbar-clear-shop" title="Clear Shopping Progress" aria-label="Clear Shopping Progress">
                     <i class="fas fa-eraser" aria-hidden="true"></i>
                 </button>

--- a/public/style.css
+++ b/public/style.css
@@ -2396,3 +2396,37 @@ h1 {
     letter-spacing: 1px;
     opacity: 0.5;
 }
+
+/* New Floating Add Item Flow */
+.add-item-row {
+    display: none !important;
+}
+
+.floating-item-row {
+    position: fixed;
+    bottom: 80px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 3000;
+    width: calc(100% - 2rem);
+    max-width: 480px;
+    height: 50px;
+    background: var(--card-bg);
+    border-radius: var(--border-radius);
+    border: 1px solid var(--border-color);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+    display: flex;
+    align-items: center;
+    padding: 0 1rem 0 0.5rem;
+    box-sizing: border-box;
+}
+
+.floating-item-row .item-info {
+    flex: 1;
+    display: flex;
+    align-items: center;
+}
+
+.floating-item-row .inline-item-input {
+    width: 100%;
+}


### PR DESCRIPTION
I have redesigned the "Add Item" flow as requested. 

Key changes include:
1.  **Toolbar Button**: A new plus icon button in the bottom toolbar now serves as the primary way to add items.
2.  **Floating Add Row**: Clicking the button spawns a floating row above the toolbar. This row is automatically focused and styled to match the list's aesthetic.
3.  **Drag-to-Add**: The floating row is draggable. Users can enter a name and then drag the item directly to any section or position in the list.
4.  **Keyboard Support**: Users can still press 'Enter' to quickly add an item to the top of the list, or 'Escape' to cancel.
5.  **Clean UI**: The old, repetitive "Add item" rows have been removed from each section, resulting in a cleaner and more modern interface.

I have updated `index.html`, `style.css`, and `app.js` to support this new interaction model, ensuring that the drag-and-drop logic correctly handles items being introduced from outside the main list container.

Fixes #299

---
*PR created automatically by Jules for task [11396278218299033814](https://jules.google.com/task/11396278218299033814) started by @camyoung1234*