### PR TITLE
Hide quantity input field border when not focused

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -990,7 +990,7 @@ h1 {
 .qty-input {
     width: 48px;
     height: 32px;
-    border: 2px solid var(--border-color);
+    border: 2px solid transparent;
     border-radius: 8px;
     background: var(--input-bg);
     color: var(--text-color);
@@ -1020,7 +1020,7 @@ h1 {
 }
 
 .shop-chip.selected .qty-input {
-    border-color: var(--primary-color);
+    border-color: transparent;
 }
 
 /* Buy Badge (Shop Mode) */


### PR DESCRIPTION
This change makes the border around quantity input fields invisible when they are not focused. 

Key changes:
- In `public/style.css`, changed `.qty-input` border to `2px solid transparent`.
- Changed `.shop-chip.selected .qty-input` border to `transparent`.
- Verified that the focus state still shows a glowing border using `background-image` and `background-clip`.

This ensures a cleaner UI while maintaining layout stability (no shifts when focusing).

Fixes #301

---
*PR created automatically by Jules for task [12910678966292054926](https://jules.google.com/task/12910678966292054926) started by @camyoung1234*