### PR TITLE
Fix item display during drag: hide handles and delete buttons, show quantity controls

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -2226,7 +2226,10 @@ h1 {
 }
 
 .is-dragging .section-delete-btn,
-.is-dragging .move-here-btn,
+.is-dragging .move-here-btn {
+    transform: translate(-50%, -50%) scale(0.5) !important;
+}
+
 .touch-ghost .section-delete-btn {
     transform: translate(-50%, -50%) scale(1) !important;
 }
@@ -2294,30 +2297,30 @@ h1 {
 }
 
 .is-dragging .drag-handle {
-    opacity: 0.5 !important;
-    pointer-events: auto !important;
-    transform: translate(-50%, -50%) scale(1) !important;
-    width: 40px !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+    transform: translate(-50%, -50%) scale(0.5) !important;
+    width: 0 !important;
 }
 
 .is-dragging .item-delete-btn,
 .is-dragging .section-delete-btn,
 .is-dragging .move-here-btn {
-    opacity: 1 !important;
-    pointer-events: auto !important;
-    visibility: visible !important;
-}
-
-.is-dragging .item-delete-btn,
-.is-dragging .section-delete-btn,
-.is-dragging .move-here-btn {
-    width: 48px !important;
-}
-
-.is-dragging .quantity-controls {
     opacity: 0 !important;
     pointer-events: none !important;
     visibility: hidden !important;
+}
+
+.is-dragging .item-delete-btn,
+.is-dragging .section-delete-btn,
+.is-dragging .move-here-btn {
+    width: 0 !important;
+}
+
+.is-dragging .quantity-controls {
+    opacity: 1 !important;
+    pointer-events: auto !important;
+    visibility: visible !important;
 }
 
 .is-dragging .add-item-row,
@@ -2329,11 +2332,11 @@ h1 {
 }
 
 .is-dragging .section-actions {
-    width: 48px !important;
-    min-width: 48px !important;
-    opacity: 1 !important;
-    pointer-events: auto !important;
-    margin-left: 0.5rem !important;
+    width: 0 !important;
+    min-width: 0 !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+    margin-left: 0 !important;
 }
 
 .is-dragging .grocery-item,

--- a/tests/drag_ui_fix.spec.js
+++ b/tests/drag_ui_fix.spec.js
@@ -1,0 +1,101 @@
+const { mockFirebase, setMockState } = require('./mockFirebase');
+const { test, expect } = require('@playwright/test');
+
+test('UI behavior of other items during drag', async ({ page }) => {
+  await mockFirebase(page);
+  await page.goto('/');
+
+  // Setup state with two items and reload
+  const listId = 'list-1';
+  const state = {
+      lists: [{
+        id: listId,
+        name: 'Test List',
+        theme: 'var(--theme-blue)',
+        homeSections: [{ id: 'sec-h-1', name: 'Test Section' }],
+        shopSections: [{ id: 'sec-s-def', name: 'Uncategorized' }],
+        items: [
+          {
+            id: 'item-1',
+            text: 'Item 1',
+            homeSectionId: 'sec-h-1',
+            shopSectionId: 'sec-s-def',
+            homeIndex: 0,
+            shopIndex: 0,
+            haveCount: 0,
+            wantCount: 1,
+            shopCompleted: false
+          },
+          {
+            id: 'item-2',
+            text: 'Item 2',
+            homeSectionId: 'sec-h-1',
+            shopSectionId: 'sec-s-def',
+            homeIndex: 1,
+            shopIndex: 1,
+            haveCount: 0,
+            wantCount: 1,
+            shopCompleted: false
+          }
+        ]
+      }],
+      currentListId: listId
+    };
+  await setMockState(page, { ...state, mode: 'home', editMode: true });
+
+  // Wait for app to render
+  const item1 = page.locator('.grocery-item[data-id="item-1"]');
+  const item2 = page.locator('.grocery-item[data-id="item-2"]');
+  await item1.waitFor({ state: 'visible' });
+  await item2.waitFor({ state: 'visible' });
+
+  // Trigger drag on item 1
+  await page.evaluate(() => {
+    localStorage.setItem('grocery-logged-in', 'true');
+    const el = document.querySelector('.grocery-item[data-id="item-1"] .drag-handle');
+    const rect = el.getBoundingClientRect();
+    const touch = new Touch({
+      identifier: Date.now(),
+      target: el,
+      clientX: rect.left + rect.width / 2,
+      clientY: rect.top + rect.height / 2,
+      pageX: rect.left + rect.width / 2,
+      pageY: rect.top + rect.height / 2,
+    });
+
+    el.dispatchEvent(new TouchEvent('touchstart', {
+      cancelable: true,
+      bubbles: true,
+      touches: [touch],
+      targetTouches: [touch],
+      changedTouches: [touch]
+    }));
+  });
+
+  // wait for the startDragging timeout to execute
+  await page.waitForTimeout(150);
+
+  // Check that .is-dragging is on html
+  await expect(page.locator('html')).toHaveClass(/is-dragging/);
+
+  // Check other item (item 2)
+  const dragHandle2 = item2.locator('.drag-handle');
+  const deleteBtn2 = item2.locator('.item-delete-btn');
+  const quantityControls2 = item2.locator('.quantity-controls');
+
+  const handleOpacity = await dragHandle2.evaluate(el => getComputedStyle(el).opacity);
+  const deleteOpacity = await deleteBtn2.evaluate(el => getComputedStyle(el).opacity);
+  const quantityOpacity = await quantityControls2.evaluate(el => getComputedStyle(el).opacity);
+  const deleteVisibility = await deleteBtn2.evaluate(el => getComputedStyle(el).visibility);
+
+  console.log('Fixed Handle Opacity:', handleOpacity);
+  console.log('Fixed Delete Opacity:', deleteOpacity);
+  console.log('Fixed Quantity Opacity:', quantityOpacity);
+  console.log('Fixed Delete Visibility:', deleteVisibility);
+
+  // Expectations for FIXED state
+  expect(parseFloat(handleOpacity)).toBe(0);
+  expect(parseFloat(deleteOpacity)).toBe(0);
+  expect(deleteVisibility).toBe('hidden');
+  expect(parseFloat(quantityOpacity)).toBe(1);
+});

--- a/tests/drag_ui_fix.spec.js
+++ b/tests/drag_ui_fix.spec.js
@@ -51,7 +51,6 @@ test('UI behavior of other items during drag', async ({ page }) => {
 
   // Trigger drag on item 1
   await page.evaluate(() => {
-    localStorage.setItem('grocery-logged-in', 'true');
     const el = document.querySelector('.grocery-item[data-id="item-1"] .drag-handle');
     const rect = el.getBoundingClientRect();
     const touch = new Touch({


### PR DESCRIPTION
This PR fixes the UI behavior when dragging a grocery item. 

Key changes:
- In `public/style.css`, modified `.is-dragging` styles to hide drag handles and delete buttons on all items except the one being dragged (which is hidden and replaced by a ghost).
- Ensured quantity controls remain visible during the drag operation to satisfy the user's requirement.
- Added a regression test `tests/drag_ui_fix.spec.js` that verifies the opacity and visibility of handles, delete buttons, and quantity controls during a simulated drag.
- Verified the fix with manual screenshots using a Playwright verification script.

Fixes #300

---
*PR created automatically by Jules for task [15528872224168569269](https://jules.google.com/task/15528872224168569269) started by @camyoung1234*