### PR TITLE
Always display quantity field in store mode

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -983,7 +983,7 @@ h1 {
     display: flex;
 }
 
-.shop-mode:not(.hide-drag-handles) .want-stepper {
+.shop-mode .want-stepper {
     display: flex;
 }
 
@@ -2236,9 +2236,7 @@ h1 {
 
 
 .home-mode:not(.hide-drag-handles) .grocery-item .quantity-controls,
-.touch-ghost.home-mode:not(.hide-drag-handles) .quantity-controls,
-.shop-mode.hide-drag-handles .grocery-item .quantity-controls,
-.touch-ghost.shop-mode.hide-drag-handles .quantity-controls {
+.touch-ghost.home-mode:not(.hide-drag-handles) .quantity-controls {
     opacity: 0;
     pointer-events: none;
     visibility: hidden;

--- a/tests/always_display_qty_shop.spec.js
+++ b/tests/always_display_qty_shop.spec.js
@@ -34,7 +34,6 @@ test('verify quantity field is always displayed in shop mode', async ({ page }) 
 
     // Switch to Shop Mode
     await page.click('#toolbar-mode');
-    await page.waitForTimeout(600); // Wait for transition
     await expect(page.locator('.app-container')).toHaveClass(/shop-mode/);
 
     // Disable editMode

--- a/tests/always_display_qty_shop.spec.js
+++ b/tests/always_display_qty_shop.spec.js
@@ -1,0 +1,47 @@
+const { mockFirebase, setMockState } = require('./mockFirebase');
+const { test, expect } = require('@playwright/test');
+
+test('verify quantity field is always displayed in shop mode', async ({ page }) => {
+    await mockFirebase(page);
+    await page.addInitScript(() => { localStorage.setItem('grocery-logged-in', 'true'); });
+    await page.goto('http://localhost:3000');
+
+    // Set up a list with one item
+    await setMockState(page, {
+        mode: 'home',
+        editMode: true,
+        lists: [{
+            id: 'list-1',
+            name: 'Test List',
+            theme: 'var(--theme-blue)',
+            accent: 'var(--theme-amber)',
+            homeSections: [{ id: 'sec-1', name: 'Fruits' }],
+            shopSections: [{ id: 'sec-s-def', name: 'Uncategorized' }],
+            items: [{
+                id: 'item-1',
+                text: 'Apple',
+                homeSectionId: 'sec-1',
+                shopSectionId: 'sec-s-def',
+                homeIndex: 0,
+                shopIndex: 0,
+                haveCount: 0,
+                wantCount: 1,
+                shopCompleted: false
+            }]
+        }],
+        currentListId: 'list-1'
+    });
+
+    // Switch to Shop Mode
+    await page.click('#toolbar-mode');
+    await page.waitForTimeout(600); // Wait for transition
+    await expect(page.locator('.app-container')).toHaveClass(/shop-mode/);
+
+    // Disable editMode
+    await page.click('#toolbar-reorder');
+    await expect(page.locator('.app-container')).toHaveClass(/hide-drag-handles/);
+
+    // Verify quantity controls are visible even when NOT in edit mode in shop mode
+    const wantStepper = page.locator('.grocery-item .want-stepper');
+    await expect(wantStepper).toBeVisible();
+});

--- a/tests/shop_stepper.spec.js
+++ b/tests/shop_stepper.spec.js
@@ -53,11 +53,11 @@ await page.addInitScript(() => { localStorage.setItem('grocery-logged-in', 'true
     await expect(wantInput).toHaveValue('1');
     await expect(circleNum).toHaveText('1');
 
-    // Exit Edit Mode and verify controls are hidden
+    // Exit Edit Mode and verify controls are STILL visible in shop mode
     await page.click('#toolbar-reorder');
     await expect(page.locator('.app-container')).toHaveClass(/hide-drag-handles/);
 
     // Wait for transition
     await page.waitForTimeout(600);
-    await expect(qtyControls).not.toBeVisible();
+    await expect(qtyControls).toBeVisible();
 });


### PR DESCRIPTION
I have modified the application to always display the quantity field when in "Store Mode" (shop mode). Previously, the quantity controls were only visible in shop mode when reordering (edit mode) was enabled. 

Key changes:
- In `public/style.css`, I updated the rules for `.quantity-controls` and `.want-stepper` to ensure they are always `display: flex` and `visibility: visible` when the application is in `shop-mode`.
- I updated the existing `tests/shop_stepper.spec.js` to reflect that the controls should now remain visible after exiting edit mode.
- I added a new test file `tests/always_display_qty_shop.spec.js` to specifically verify this requirement and prevent future regressions.
- I verified the visual change by generating a screenshot in a mocked environment.

Fixes #305

---
*PR created automatically by Jules for task [5456171134372020890](https://jules.google.com/task/5456171134372020890) started by @camyoung1234*