### PR TITLE
Single tap to edit in store mode

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -200,15 +200,18 @@ document.addEventListener('DOMContentLoaded', async () => {
                     selectionRenderTimeout = null;
                 }, 300);
             } else {
-                // Regular Shop Mode: toggle completion
-                toggleShopCompleted(id);
+                // Regular Shop Mode: toggle completion ONLY on circle click
+                if (target.closest('.shop-qty-circle')) {
+                    toggleShopCompleted(id);
+                    return;
+                }
+                // Otherwise fall through to show-controls logic
             }
-            return;
         }
 
-        // Single tap to show controls in Home mode when NOT in global editMode
+        // Single tap to show controls in Home or Shop mode when NOT in global editMode
         const groceryItem = target.closest('.grocery-item');
-        if (groceryItem && !editMode && currentMode === 'home' && !groceryItem.classList.contains('add-item-row')) {
+        if (groceryItem && !editMode && (currentMode === 'home' || currentMode === 'shop') && !groceryItem.classList.contains('add-item-row')) {
             const id = groceryItem.dataset.id;
             const item = getCurrentList().items.find(i => i.id === id);
             if (!item) return;

--- a/public/style.css
+++ b/public/style.css
@@ -1949,7 +1949,21 @@ h1 {
     visibility: visible !important;
 }
 
-.grocery-item.show-controls .quantity-controls {
+.home-mode .grocery-item.show-controls .quantity-controls {
+    opacity: 0 !important;
+    pointer-events: none !important;
+    visibility: hidden !important;
+}
+
+.shop-mode .grocery-item.show-controls .quantity-controls,
+.shop-mode .grocery-item.show-controls .want-stepper {
+    opacity: 1 !important;
+    pointer-events: auto !important;
+    visibility: visible !important;
+    display: flex !important;
+}
+
+.shop-mode .grocery-item.show-controls .shop-qty-circle {
     opacity: 0 !important;
     pointer-events: none !important;
     visibility: hidden !important;

--- a/tests/shared_want.spec.js
+++ b/tests/shared_want.spec.js
@@ -179,7 +179,7 @@ test('Committing a grouped item in Shop mode distributes haveCount correctly', a
         await setMockState(page, state);
 
     const bananaRow = page.locator('.grocery-item:has-text("Bananas")');
-    await bananaRow.locator('.item-text').click();
+    await bananaRow.locator('.shop-qty-circle').click();
 
     // Wait for completion animation
     await expect(bananaRow).toHaveClass(/completed/, { timeout: 10000 });


### PR DESCRIPTION
This change implements a more intuitive interaction model for Shop Mode. Previously, tapping anywhere on a row would toggle the item's completion status. Now:
1. Tapping the row (outside the checkbox) toggles "edit" controls for that item, showing the drag handle and the quantity field.
2. Tapping the checkbox circle specifically is now required to check off an item.
3. If the controls are already visible, tapping the item's text allows for inline editing of the item name.

These changes were achieved by updating the event delegation logic in `public/app.js` and adding specific CSS rules in `public/style.css` to manage the visibility of elements when an item is in the 'show-controls' state during Shop Mode. Existing tests were updated where necessary to follow the new interaction pattern.

Fixes #306

---
*PR created automatically by Jules for task [11631435552402841520](https://jules.google.com/task/11631435552402841520) started by @camyoung1234*