### PR TITLE
Clear editing state on quantity field focus

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -231,6 +231,30 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     });
 
+    groceryList.addEventListener('focusin', (e) => {
+        if (e.target.classList.contains('qty-input')) {
+            // Deactivate any item controls
+            groceryList.querySelectorAll('.grocery-item.show-controls').forEach(el => el.classList.remove('show-controls'));
+
+            // Blur any active inline name editing field
+            const activeInlineInput = document.querySelector('.inline-edit-input');
+            if (activeInlineInput && activeInlineInput !== e.target) {
+                // Capture state to restore focus if renderList is called
+                const itemRow = e.target.closest('.grocery-item');
+                const focusedId = itemRow?.dataset.id;
+                const wasType = e.target.closest('.have-stepper') ? 'have' : 'want';
+
+                activeInlineInput.blur();
+
+                // If blur caused a re-render (which it does via saveName), restore focus
+                if (focusedId && (!e.target.isConnected || document.activeElement !== e.target)) {
+                    const newInput = document.querySelector(`.grocery-item[data-id="${focusedId}"] .${wasType}-stepper .qty-input`);
+                    if (newInput) newInput.focus();
+                }
+            }
+        }
+    });
+
     groceryList.addEventListener('submit', (e) => {
         const target = e.target;
 

--- a/tests/repro_focus_qty.spec.js
+++ b/tests/repro_focus_qty.spec.js
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { mockFirebase } from './mockFirebase';
+
+test.describe('Focus quantity field behavior', () => {
+    test.beforeEach(async ({ page }) => {
+        await mockFirebase(page);
+        await page.goto('/');
+        await page.waitForSelector('.app-container:not(.hidden)');
+
+        // Ensure we are in home mode and not in global edit mode for show-controls testing
+        await page.evaluate(() => {
+            localStorage.setItem('grocery-mode', 'home');
+            localStorage.setItem('grocery-edit-mode', 'false');
+            window.location.reload();
+        });
+        await page.waitForSelector('.app-container:not(.hidden)');
+
+        // Add a section first
+        await page.fill('.add-section-input', 'My Section');
+        await page.press('.add-section-input', 'Enter');
+        await page.waitForSelector('.section-container');
+    });
+
+    test('focusing quantity field clears show-controls from another item', async ({ page }) => {
+        // Add two items
+        await page.fill('.add-item-input', 'Item 1');
+        await page.press('.add-item-input', 'Enter');
+        await page.fill('.add-item-input', 'Item 2');
+        await page.press('.add-item-input', 'Enter');
+
+        const item1 = page.locator('.grocery-item').filter({ hasText: 'Item 1' });
+        const item2 = page.locator('.grocery-item').filter({ hasText: 'Item 2' });
+
+        // Single tap Item 1 to show controls
+        await item1.click();
+        await expect(item1).toHaveClass(/show-controls/);
+
+        // Focus Item 2's quantity field
+        const qty2 = item2.locator('.qty-input');
+        await qty2.focus();
+
+        // Item 1 should no longer have show-controls
+        await expect(item1).not.toHaveClass(/show-controls/);
+    });
+
+    test('focusing quantity field clears inline edit from another item', async ({ page }) => {
+        // Enable global edit mode to allow double tap to edit
+        await page.evaluate(() => {
+            localStorage.setItem('grocery-edit-mode', 'true');
+            window.location.reload();
+        });
+        await page.waitForSelector('.app-container:not(.hidden)');
+
+        // Add two items
+        await page.fill('.add-item-input', 'Item 1');
+        await page.press('.add-item-input', 'Enter');
+        await page.fill('.add-item-input', 'Item 2');
+        await page.press('.add-item-input', 'Enter');
+
+        const item1 = page.locator('.grocery-item').filter({ hasText: 'Item 1' });
+        const item2 = page.locator('.grocery-item').filter({ hasText: 'Item 2' });
+
+        // Double click Item 1 to start inline edit
+        await item1.locator('.item-text').dblclick();
+        await expect(item1.locator('.inline-edit-input')).toBeVisible();
+
+        // Focus Item 2's quantity field
+        const qty2 = item2.locator('.qty-input');
+        await qty2.focus();
+
+        // Item 1 should no longer be in edit mode (inline-edit-input should be gone)
+        // Note: blurring might trigger a renderList which clears it.
+        await expect(item1.locator('.inline-edit-input')).not.toBeAttached();
+    });
+});

--- a/tests/repro_focus_qty.spec.js
+++ b/tests/repro_focus_qty.spec.js
@@ -1,38 +1,37 @@
 import { test, expect } from '@playwright/test';
-import { mockFirebase } from './mockFirebase';
+import { mockFirebase, setMockState } from './mockFirebase';
 
 test.describe('Focus quantity field behavior', () => {
     test.beforeEach(async ({ page }) => {
         await mockFirebase(page);
         await page.goto('/');
         await page.waitForSelector('.app-container:not(.hidden)');
-
-        // Ensure we are in home mode and not in global edit mode for show-controls testing
-        await page.evaluate(() => {
-            localStorage.setItem('grocery-mode', 'home');
-            localStorage.setItem('grocery-edit-mode', 'false');
-            window.location.reload();
-        });
-        await page.waitForSelector('.app-container:not(.hidden)');
-
-        // Add a section first
-        await page.fill('.add-section-input', 'My Section');
-        await page.press('.add-section-input', 'Enter');
-        await page.waitForSelector('.section-container');
     });
 
     test('focusing quantity field clears show-controls from another item', async ({ page }) => {
-        // Add two items
-        await page.fill('.add-item-input', 'Item 1');
-        await page.press('.add-item-input', 'Enter');
-        await page.fill('.add-item-input', 'Item 2');
-        await page.press('.add-item-input', 'Enter');
+        await setMockState(page, {
+            mode: 'home',
+            editMode: false,
+            lists: [{
+                id: 'list-1',
+                name: 'Grocery List',
+                theme: 'var(--theme-blue)',
+                accent: 'var(--theme-amber)',
+                homeSections: [{ id: 'sec-1', name: 'Section 1' }],
+                shopSections: [{ id: 'sec-s-def', name: 'Uncategorized' }],
+                items: [
+                    { id: 'item-1', text: 'Item 1', homeSectionId: 'sec-1', shopSectionId: 'sec-s-def', haveCount: 0, wantCount: 1, shopCompleted: false, homeIndex: 0, shopIndex: 0 },
+                    { id: 'item-2', text: 'Item 2', homeSectionId: 'sec-1', shopSectionId: 'sec-s-def', haveCount: 0, wantCount: 1, shopCompleted: false, homeIndex: 1, shopIndex: 1 }
+                ]
+            }]
+        });
 
-        const item1 = page.locator('.grocery-item').filter({ hasText: 'Item 1' });
-        const item2 = page.locator('.grocery-item').filter({ hasText: 'Item 2' });
+        const item1 = page.locator('.grocery-item[data-id="item-1"]');
+        const item2 = page.locator('.grocery-item[data-id="item-2"]');
+        await expect(item1).toBeVisible();
 
         // Single tap Item 1 to show controls
-        await item1.click();
+        await item1.locator('.item-text').click();
         await expect(item1).toHaveClass(/show-controls/);
 
         // Focus Item 2's quantity field
@@ -44,32 +43,39 @@ test.describe('Focus quantity field behavior', () => {
     });
 
     test('focusing quantity field clears inline edit from another item', async ({ page }) => {
-        // Enable global edit mode to allow double tap to edit
-        await page.evaluate(() => {
-            localStorage.setItem('grocery-edit-mode', 'true');
-            window.location.reload();
+        await setMockState(page, {
+            mode: 'home',
+            editMode: true,
+            lists: [{
+                id: 'list-1',
+                name: 'Grocery List',
+                theme: 'var(--theme-blue)',
+                accent: 'var(--theme-amber)',
+                homeSections: [{ id: 'sec-1', name: 'Section 1' }],
+                shopSections: [{ id: 'sec-s-def', name: 'Uncategorized' }],
+                items: [
+                    { id: 'item-1', text: 'Item 1', homeSectionId: 'sec-1', shopSectionId: 'sec-s-def', haveCount: 0, wantCount: 1, shopCompleted: false, homeIndex: 0, shopIndex: 0 },
+                    { id: 'item-2', text: 'Item 2', homeSectionId: 'sec-1', shopSectionId: 'sec-s-def', haveCount: 0, wantCount: 1, shopCompleted: false, homeIndex: 1, shopIndex: 1 }
+                ]
+            }]
         });
-        await page.waitForSelector('.app-container:not(.hidden)');
 
-        // Add two items
-        await page.fill('.add-item-input', 'Item 1');
-        await page.press('.add-item-input', 'Enter');
-        await page.fill('.add-item-input', 'Item 2');
-        await page.press('.add-item-input', 'Enter');
+        const item1 = page.locator('.grocery-item[data-id="item-1"]');
+        const item2 = page.locator('.grocery-item[data-id="item-2"]');
+        await expect(item1).toBeVisible();
 
-        const item1 = page.locator('.grocery-item').filter({ hasText: 'Item 1' });
-        const item2 = page.locator('.grocery-item').filter({ hasText: 'Item 2' });
+        // Simulate double tap using two clicks as custom onDoubleTap uses click timing
+        await item1.locator('.item-text').click();
+        await item1.locator('.item-text').click();
 
-        // Double click Item 1 to start inline edit
-        await item1.locator('.item-text').dblclick();
-        await expect(item1.locator('.inline-edit-input')).toBeVisible();
+        const inlineInput = item1.locator('.inline-edit-input');
+        await expect(inlineInput).toBeVisible();
 
         // Focus Item 2's quantity field
         const qty2 = item2.locator('.qty-input');
         await qty2.focus();
 
-        // Item 1 should no longer be in edit mode (inline-edit-input should be gone)
-        // Note: blurring might trigger a renderList which clears it.
-        await expect(item1.locator('.inline-edit-input')).not.toBeAttached();
+        // Item 1 should no longer be in edit mode
+        await expect(inlineInput).not.toBeAttached();
     });
 });


### PR DESCRIPTION
Implement logic to stop editing an item when the user focuses on any quantity field. This is achieved by listening for 'focusin' events on the grocery list and clearing both the 'show-controls' class and any active inline editing inputs when a '.qty-input' is focused.

Fixes #309

---
*PR created automatically by Jules for task [15129891295166973943](https://jules.google.com/task/15129891295166973943) started by @camyoung1234*