### PR TITLE
Single tap to edit sections

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -226,7 +226,43 @@ document.addEventListener('DOMContentLoaded', async () => {
                 e.stopPropagation();
                 // Deactivate others
                 groceryList.querySelectorAll('.grocery-item.show-controls').forEach(el => el.classList.remove('show-controls'));
+                groceryList.querySelectorAll('.section-header.show-controls').forEach(el => el.classList.remove('show-controls'));
                 groceryItem.classList.add('show-controls');
+            }
+        }
+
+        // Single tap to show controls on sections
+        const sectionHeader = target.closest('.section-header');
+        if (sectionHeader && !target.closest('.drag-handle') && !target.closest('.section-delete-btn') && !target.closest('.move-here-btn')) {
+            const container = sectionHeader.closest('.section-container');
+            const section = getCurrentList().homeSections.find(s => s.id === container.dataset.id) ||
+                            getCurrentList().shopSections.find(s => s.id === container.dataset.id);
+            if (!section) return;
+
+            const isTitleClick = target.classList.contains('section-title');
+            const canRename = currentMode === 'home' || section.id !== shopDefId;
+
+            if (editMode) {
+                if (isTitleClick && canRename) {
+                    e.stopPropagation();
+                    startInlineSectionEdit(section, sectionHeader, target);
+                }
+            } else {
+                // If title clicked while controls are already shown, start inline edit
+                if (isTitleClick && sectionHeader.classList.contains('show-controls') && canRename) {
+                    e.stopPropagation();
+                    startInlineSectionEdit(section, sectionHeader, target);
+                    return;
+                }
+
+                // Otherwise, just toggle controls
+                if (!sectionHeader.classList.contains('show-controls')) {
+                    e.stopPropagation();
+                    // Deactivate others
+                    groceryList.querySelectorAll('.grocery-item.show-controls').forEach(el => el.classList.remove('show-controls'));
+                    groceryList.querySelectorAll('.section-header.show-controls').forEach(el => el.classList.remove('show-controls'));
+                    sectionHeader.classList.add('show-controls');
+                }
             }
         }
     });
@@ -297,45 +333,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             return;
         }
 
-        // Section Title Double Tap
-        if (target.classList.contains('section-title')) {
-            e.stopPropagation();
-            const container = target.closest('.section-container');
-            const section = getCurrentList().homeSections.find(s => s.id === container.dataset.id) ||
-                            getCurrentList().shopSections.find(s => s.id === container.dataset.id);
-
-            if (section && (currentMode === 'home' || section.id !== shopDefId)) {
-                const header = target.closest('.section-header');
-                const input = document.createElement('input');
-                input.type = 'text';
-                input.autocomplete = 'off';
-                input.value = section.name;
-                input.className = 'inline-section-input';
-                applyManualSelection(input);
-
-                const saveSectionName = () => {
-                    const newName = input.value.trim();
-                    if (newName && newName !== section.name) {
-                        section.name = newName;
-                        saveAppState();
-                    }
-                    renderList();
-                };
-
-                input.addEventListener('blur', saveSectionName);
-                input.addEventListener('keydown', (ke) => {
-                    if (ke.key === 'Enter') {
-                        input.blur();
-                    } else if (ke.key === 'Escape') {
-                        renderList();
-                    }
-                });
-
-                header.replaceChild(input, target);
-                input.focus();
-            }
-            return;
-        }
     });
 
     // Drag start delegation
@@ -1572,6 +1569,36 @@ document.addEventListener('DOMContentLoaded', async () => {
         input.focus();
     }
 
+    function startInlineSectionEdit(section, header, titleSpan) {
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.autocomplete = 'off';
+        input.value = section.name;
+        input.className = 'inline-section-input';
+        applyManualSelection(input);
+
+        const saveSectionName = () => {
+            const newName = input.value.trim();
+            if (newName && newName !== section.name) {
+                section.name = newName;
+                saveAppState();
+            }
+            renderList();
+        };
+
+        input.addEventListener('blur', saveSectionName);
+        input.addEventListener('keydown', (ke) => {
+            if (ke.key === 'Enter') {
+                input.blur();
+            } else if (ke.key === 'Escape') {
+                renderList();
+            }
+        });
+
+        header.replaceChild(input, titleSpan);
+        input.focus();
+    }
+
     function addSection(name, isHome) {
         const currentList = getCurrentList();
         const trimmedName = name.trim();
@@ -2376,6 +2403,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         const groceryItem = e.target.closest('.grocery-item');
         if (!groceryItem || !groceryItem.classList.contains('show-controls')) {
             groceryList.querySelectorAll('.grocery-item.show-controls').forEach(el => el.classList.remove('show-controls'));
+        }
+
+        // Deactivate section controls when clicking outside the header
+        const sectionHeader = e.target.closest('.section-header');
+        if (!sectionHeader || !sectionHeader.classList.contains('show-controls')) {
+            groceryList.querySelectorAll('.section-header.show-controls').forEach(el => el.classList.remove('show-controls'));
         }
     });
 

--- a/public/style.css
+++ b/public/style.css
@@ -2013,6 +2013,23 @@ h1 {
     transition: width 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.3s ease, margin-left 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) !important;
 }
 
+.section-header.show-controls .left-action,
+.section-header.show-controls .section-actions {
+    width: 48px !important;
+    min-width: 48px !important;
+    opacity: 1 !important;
+    pointer-events: auto !important;
+    margin-left: 0.5rem !important;
+}
+
+.section-header.show-controls .drag-handle,
+.section-header.show-controls .section-delete-btn {
+    opacity: 1 !important;
+    transform: translate(-50%, -50%) scale(1) !important;
+    pointer-events: auto !important;
+    width: 48px !important;
+}
+
 
 
 .app-container:not(.hide-drag-handles) .grocery-item .item-delete-btn {


### PR DESCRIPTION
Implemented single tap gesture for sections to reveal controls and enable inline editing. When the app is not in global edit mode, a single tap on a section header now reveals its drag handle and delete button (using the `.show-controls` class). A subsequent tap on the section name starts inline editing. If the app is already in global edit mode, a single tap on the section name starts editing immediately. The redundant double-tap handler for sections was removed. CSS was updated to ensure that section actions are visible when the `.show-controls` class is applied, even if drag handles are globally hidden.

Fixes #311

---
*PR created automatically by Jules for task [8821607612586249728](https://jules.google.com/task/8821607612586249728) started by @camyoung1234*