### PR TITLE
Add cancel button and tap-outside dismissal to logout prompt

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -435,6 +435,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const syncLoginBtn = document.getElementById('sync-login-btn');
     const syncSignupBtn = document.getElementById('sync-signup-btn');
     const syncLogoutBtn = document.getElementById('sync-logout-btn');
+    const syncCancelBtn = document.getElementById('sync-cancel-btn');
     const syncUserEmailSpan = document.getElementById('sync-user-email');
     const syncErrorDiv = document.getElementById('sync-error');
     const syncMessageDiv = document.getElementById('sync-message');
@@ -796,6 +797,22 @@ document.addEventListener('DOMContentLoaded', async () => {
                 await signInWithEmailAndPassword(auth, email, password);
             } catch (e) {
                 showSyncError(e.message);
+            }
+        });
+    }
+
+    if (syncCancelBtn) {
+        syncCancelBtn.addEventListener('click', () => {
+            if (isAppRunning) {
+                syncModalOverlay.classList.remove('visible');
+            }
+        });
+    }
+
+    if (syncModalOverlay) {
+        syncModalOverlay.addEventListener('mousedown', (e) => {
+            if (e.target === syncModalOverlay && isAppRunning) {
+                syncModalOverlay.classList.remove('visible');
             }
         });
     }

--- a/public/index.html
+++ b/public/index.html
@@ -184,6 +184,7 @@
                 <p>Logged in as: <strong id="sync-user-email"></strong></p>
                 <div class="modal-actions" style="flex-direction: column; gap: 0.5rem;">
                     <button id="sync-logout-btn" class="modal-btn delete" style="width: 100%;">Logout</button>
+                    <button id="sync-cancel-btn" class="modal-btn cancel" style="width: 100%;">Cancel</button>
                 </div>
             </div>
         </div>

--- a/tests/logout_cancel.spec.js
+++ b/tests/logout_cancel.spec.js
@@ -1,0 +1,65 @@
+const { test, expect } = require('@playwright/test');
+const { mockFirebase } = require('./mockFirebase');
+
+test.describe('Logout Prompt Cancel', () => {
+    test('should allow canceling logout via Cancel button', async ({ page }) => {
+        // Start with an authenticated user
+        await mockFirebase(page, {
+            user: { uid: 'test-user', email: 'test@example.com' }
+        });
+        await page.goto('http://localhost:3000');
+
+        // Wait for app to load and login wall to disappear
+        await expect(page.locator('.app-container')).toBeVisible();
+        await expect(page.locator('#sync-modal-overlay')).toBeHidden();
+
+        // Open sync modal
+        await page.click('#toolbar-sync');
+        const syncModalOverlay = page.locator('#sync-modal-overlay');
+        await expect(syncModalOverlay).toBeVisible();
+
+        // Click Cancel button
+        await page.click('#sync-cancel-btn');
+        await expect(syncModalOverlay).toBeHidden();
+    });
+
+    test('should allow canceling logout by clicking outside the modal', async ({ page }) => {
+        // Start with an authenticated user
+        await mockFirebase(page, {
+            user: { uid: 'test-user', email: 'test@example.com' }
+        });
+        await page.goto('http://localhost:3000');
+
+        // Wait for app to load
+        await expect(page.locator('.app-container')).toBeVisible();
+
+        // Open sync modal
+        await page.click('#toolbar-sync');
+        const syncModalOverlay = page.locator('#sync-modal-overlay');
+        await expect(syncModalOverlay).toBeVisible();
+
+        // Click on the overlay (outside the modal)
+        // syncModalOverlay is the full-screen div
+        await syncModalOverlay.click({ position: { x: 5, y: 5 } });
+        await expect(syncModalOverlay).toBeHidden();
+    });
+
+    test('should NOT allow closing the modal by clicking outside when logged out', async ({ page }) => {
+        // Start WITHOUT an authenticated user
+        await mockFirebase(page, { user: null });
+        // Ensure we don't auto-bypass the wall in mockFirebase
+        await page.addInitScript(() => { localStorage.removeItem('grocery-logged-in'); });
+
+        await page.goto('http://localhost:3000');
+
+        const syncModalOverlay = page.locator('#sync-modal-overlay');
+        await expect(syncModalOverlay).toBeVisible();
+        await expect(page.locator('.app-container')).toBeHidden();
+
+        // Attempt to click outside the modal
+        await syncModalOverlay.click({ position: { x: 5, y: 5 } });
+
+        // Modal should still be visible (login wall is mandatory)
+        await expect(syncModalOverlay).toBeVisible();
+    });
+});


### PR DESCRIPTION
The logout prompt now includes a 'Cancel' button, providing users with a clear way to dismiss the modal without logging out. Additionally, users can now tap or click on the backdrop overlay to close the modal. 

Crucially, these dismissal options are only active when the application is in an authenticated state. This ensures that the initial sign-in modal (the 'login wall') remains mandatory and cannot be bypassed by unauthenticated users, maintaining the security and integrity of the application.

Verification was performed using:
1.  **Automated Tests:** A new test suite `tests/logout_cancel.spec.js` was created and passed, along with `tests/login_requirement.spec.js`.
2.  **Visual Verification:** A screenshot was taken to confirm the correct placement and styling of the new 'Cancel' button within the logout prompt.

Fixes #315

---
*PR created automatically by Jules for task [6465173953265218856](https://jules.google.com/task/6465173953265218856) started by @camyoung1234*