### PR TITLE
Add true black dark mode theme toggle

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -386,6 +386,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     const displayOptions = document.getElementById('display-options');
     const currentDisplaySwatch = document.getElementById('current-display-swatch');
     const currentDisplayName = document.getElementById('current-display-name');
+    const trueBlackGroup = document.getElementById('modal-true-black-group');
+    const trueBlackToggle = document.getElementById('true-black-toggle');
 
     const modalThemeGroup = document.getElementById('modal-theme-group');
     const themeDropdown = document.getElementById('theme-dropdown');
@@ -1063,6 +1065,13 @@ document.addEventListener('DOMContentLoaded', async () => {
             opt.classList.toggle('selected', opt.dataset.value === value);
         });
 
+        // Show/hide true black toggle based on display mode
+        if (value === 'light') {
+            trueBlackGroup.classList.add('hidden');
+        } else {
+            trueBlackGroup.classList.remove('hidden');
+        }
+
         // Trigger live preview
         document.documentElement.classList.remove('dark-mode', 'light-mode');
         if (value === 'dark') document.documentElement.classList.add('dark-mode');
@@ -1166,7 +1175,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     let currentModalCallback = null;
     let currentDeleteActionCallback = null;
 
-    function showModal(title, initialValue, showTheme, initialTheme, initialAccent, initialDisplayMode, callback, deleteCallback) {
+    function showModal(title, initialValue, showTheme, initialTheme, initialAccent, initialDisplayMode, initialTrueBlack, callback, deleteCallback) {
         modalTitle.textContent = title;
         modalInput.value = initialValue || '';
 
@@ -1177,10 +1186,12 @@ document.addEventListener('DOMContentLoaded', async () => {
             selectDisplayMode(initialDisplayMode || 'auto');
             selectTheme(initialTheme || 'var(--theme-blue)');
             selectAccent(initialAccent || 'var(--theme-amber)');
+            trueBlackToggle.checked = !!initialTrueBlack;
         } else {
             modalDisplayGroup.classList.add('hidden');
             modalThemeGroup.classList.add('hidden');
             modalAccentGroup.classList.add('hidden');
+            trueBlackGroup.classList.add('hidden');
         }
 
         if (deleteCallback) {
@@ -1201,6 +1212,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         displayDropdown.classList.remove('open');
         themeDropdown.classList.remove('open');
         accentDropdown.classList.remove('open');
+        trueBlackToggle.checked = false;
         currentModalCallback = null;
         currentDeleteActionCallback = null;
         updateModeUI(); // Restore original theme
@@ -1220,8 +1232,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         const theme = !modalThemeGroup.classList.contains('hidden') ? selectedThemeValue : null;
         const accent = !modalAccentGroup.classList.contains('hidden') ? selectedAccentValue : null;
         const displayMode = !modalDisplayGroup.classList.contains('hidden') ? selectedDisplayModeValue : null;
+        const trueBlack = !trueBlackGroup.classList.contains('hidden') ? trueBlackToggle.checked : false;
         if (currentModalCallback) {
-            currentModalCallback(val, theme, accent, displayMode);
+            currentModalCallback(val, theme, accent, displayMode, trueBlack);
         }
         hideModal();
     });
@@ -1234,8 +1247,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             const theme = !modalThemeGroup.classList.contains('hidden') ? selectedThemeValue : null;
             const accent = !modalAccentGroup.classList.contains('hidden') ? selectedAccentValue : null;
             const displayMode = !modalDisplayGroup.classList.contains('hidden') ? selectedDisplayModeValue : null;
+            const trueBlack = !trueBlackGroup.classList.contains('hidden') ? trueBlackToggle.checked : false;
             if (currentModalCallback) {
-                currentModalCallback(val, theme, accent, displayMode);
+                currentModalCallback(val, theme, accent, displayMode, trueBlack);
             }
             hideModal();
         }
@@ -1471,13 +1485,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     // --- List Management ---
-    function addNewList(name, theme, accent, displayMode) {
+    function addNewList(name, theme, accent, displayMode, trueBlack) {
         const newList = {
             id: Date.now().toString(),
             name: name,
             theme: theme || 'var(--theme-blue)',
             accent: accent || 'var(--theme-amber)',
             displayMode: displayMode || 'auto',
+            trueBlack: !!trueBlack,
             homeSections: [], // Start with no sections in Home Mode
             shopSections: [{ id: 'sec-s-def', name: 'Uncategorized' }],
             items: []
@@ -1504,12 +1519,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         const list = appState.lists.find(l => l.id === id);
         if (!list) return;
 
-        showModal('Edit List', list.name, true, list.theme, list.accent, list.displayMode, (newName, newTheme, newAccent, newDisplayMode) => {
+        showModal('Edit List', list.name, true, list.theme, list.accent, list.displayMode, list.trueBlack, (newName, newTheme, newAccent, newDisplayMode, newTrueBlack) => {
             if (newName) {
                 list.name = newName;
                 if (newTheme) list.theme = newTheme;
                 if (newAccent) list.accent = newAccent;
                 if (newDisplayMode) list.displayMode = newDisplayMode;
+                list.trueBlack = !!newTrueBlack;
                 saveAppState();
                 renderListsMenu();
                 updateModeUI(); // Re-apply theme if current list changed
@@ -1920,11 +1936,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         document.documentElement.style.setProperty('--accent-color', accentColor);
 
         // Apply display mode
-        document.documentElement.classList.remove('dark-mode', 'light-mode');
+        document.documentElement.classList.remove('dark-mode', 'light-mode', 'true-black');
         if (currentList) {
             const displayMode = currentList.displayMode || 'auto';
             if (displayMode === 'dark') document.documentElement.classList.add('dark-mode');
             if (displayMode === 'light') document.documentElement.classList.add('light-mode');
+            if (currentList.trueBlack) document.documentElement.classList.add('true-black');
         }
 
         // Update theme-color meta tag
@@ -2009,8 +2026,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         addBtn.className = 'menu-item';
         addBtn.innerHTML = '<i class="fas fa-plus" style="width: 12px; text-align: center;"></i> <span class="create-list-text">Create New List</span>';
         addBtn.addEventListener('click', () => {
-            showModal('Create New List', 'New List', true, 'var(--theme-blue)', 'var(--theme-amber)', 'auto', (name, theme, accent, displayMode) => {
-                if (name) addNewList(name, theme, accent, displayMode);
+            showModal('Create New List', 'New List', true, 'var(--theme-blue)', 'var(--theme-amber)', 'auto', false, (name, theme, accent, displayMode, trueBlack) => {
+                if (name) addNewList(name, theme, accent, displayMode, trueBlack);
             });
             toggleListsMenu(false);
         });

--- a/public/index.html
+++ b/public/index.html
@@ -87,6 +87,14 @@
                 </div>
             </div>
 
+            <div class="form-group form-group-row" id="modal-true-black-group">
+                <label class="modal-label" for="true-black-toggle">True Black Dark Mode</label>
+                <label class="switch">
+                    <input type="checkbox" id="true-black-toggle">
+                    <span class="slider"></span>
+                </label>
+            </div>
+
             <div class="form-group" id="modal-theme-group">
                 <label class="modal-label">Theme</label>
                 <div class="custom-theme-dropdown" id="theme-dropdown">

--- a/public/style.css
+++ b/public/style.css
@@ -75,6 +75,13 @@
     --shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 
+:root.dark-mode.true-black {
+    --secondary-color: #000000;
+    --card-bg: #000000;
+    --hover-bg: #121212;
+    --border-color: #222;
+}
+
 @media (prefers-color-scheme: dark) {
     :root:not(.light-mode) {
         /* Theme Colors (Dark Mode) - Material 300 for better contrast on dark bg */
@@ -106,6 +113,13 @@
         --hover-bg: #2a2a2a;
         --border-color: #333;
         --shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+    }
+
+    :root:not(.light-mode).true-black {
+        --secondary-color: #000000;
+        --card-bg: #000000;
+        --hover-bg: #121212;
+        --border-color: #222;
     }
 }
 
@@ -1110,6 +1124,62 @@ h1 {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+}
+
+.form-group-row {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+}
+
+/* Switch styling */
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 44px;
+    height: 24px;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: var(--border-color);
+    transition: .3s;
+    border-radius: 24px;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 18px;
+    width: 18px;
+    left: 3px;
+    bottom: 3px;
+    background-color: white;
+    transition: .3s;
+    border-radius: 50%;
+}
+
+input:checked+.slider {
+    background-color: var(--primary-color);
+}
+
+input:focus+.slider {
+    box-shadow: 0 0 1px var(--primary-color);
+}
+
+input:checked+.slider:before {
+    transform: translateX(20px);
 }
 
 .form-group.hidden {


### PR DESCRIPTION
Implemented a "True Black" theme option for dark mode. Users can now toggle between the standard dark gray and a pure black background for each list. This was achieved by:
1. Defining CSS variable overrides for a `.true-black` class in `public/style.css`.
2. Adding a toggle switch UI in the `public/index.html` modal.
3. Updating the list management and UI logic in `public/app.js` to handle the new property and apply it dynamically.

Fixes #314

---
*PR created automatically by Jules for task [13518152663267126079](https://jules.google.com/task/13518152663267126079) started by @camyoung1234*