### PR TITLE
Floating bottom toolbar with rounded edges

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -342,7 +342,7 @@ h1 {
     padding: 0;
     margin: 0;
     flex: 1;
-    padding-bottom: 80px;
+    padding-bottom: 120px;
 }
 
 /* Swipe slide transition (Retained for potential legacy use) */
@@ -1681,18 +1681,19 @@ h1 {
 /* Bottom Toolbar */
 .bottom-toolbar {
     position: fixed;
-    bottom: 0;
+    bottom: 1rem;
     left: 50%;
     transform: translateX(-50%);
-    width: 100%;
-    max-width: 500px;
+    width: calc(100% - 2rem);
+    max-width: 460px;
     background: var(--card-bg);
     padding: 0.75rem 1rem;
     display: grid;
     grid-template-columns: 1fr auto;
     align-items: center;
-    box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.05);
-    border-top: 1px solid var(--border-color);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+    border: 1px solid var(--border-color);
+    border-radius: 24px;
     z-index: 1000;
     box-sizing: border-box;
 }
@@ -1700,8 +1701,8 @@ h1 {
 @media (min-width: 600px) {
     .bottom-toolbar {
         position: sticky;
-        border-bottom-left-radius: var(--border-radius);
-        border-bottom-right-radius: var(--border-radius);
+        bottom: 1rem;
+        margin: 0 auto 1rem auto;
     }
 }
 


### PR DESCRIPTION
The bottom navigation bar has been transformed into a modern floating toolbar. 

### Key Changes:
- **Floating Design:** The toolbar now sits `1rem` above the bottom of the viewport instead of being pinned to the edge.
- **Rounded Aesthetics:** Applied a `24px` border radius and a refined shadow to create a cohesive floating look.
- **Improved Scrollability:** Increased the bottom padding of the grocery list to `120px`, ensuring that even the last item in the list can be scrolled completely into view above the floating bar.
- **Responsive Layout:** On larger screens, the toolbar uses `position: sticky` to maintain its floating appearance within the app container.

Verification was performed using Playwright tests across multiple viewport sizes.

Fixes #319

---
*PR created automatically by Jules for task [11478837002775646327](https://jules.google.com/task/11478837002775646327) started by @camyoung1234*