### PR TITLE
Add custom numpad for quantity inputs

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -64,6 +64,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     const groceryList = document.getElementById('grocery-list');
     const appContainer = document.querySelector('.app-container');
     const listsMenu = document.getElementById('lists-menu');
+    const toolbarMain = document.getElementById('toolbar-main');
+    const toolbarNumpad = document.getElementById('toolbar-numpad');
 
     // --- Intersection Observer for Performance ---
     const inViewportSet = new Set();
@@ -2356,6 +2358,52 @@ document.addEventListener('DOMContentLoaded', async () => {
         newlyDeletedIds.clear();
     }
 
+    let activeQtyInput = null;
+
+    function focusNextQtyInput(currentInput) {
+        const allInputs = Array.from(document.querySelectorAll('.qty-input'));
+        const visibleInputs = allInputs.filter(inp => {
+            const style = window.getComputedStyle(inp.parentElement);
+            return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+        });
+        const idx = visibleInputs.indexOf(currentInput);
+        if (idx !== -1 && idx < visibleInputs.length - 1) {
+            visibleInputs[idx + 1].focus();
+        } else {
+            currentInput.blur();
+        }
+    }
+
+    function handleNumpadClick(key) {
+        if (!activeQtyInput) return;
+
+        let val = activeQtyInput.value;
+        if (key === 'backspace') {
+            val = val.slice(0, -1);
+        } else if (key === 'enter') {
+            focusNextQtyInput(activeQtyInput);
+            return;
+        } else {
+            // If value is currently "0", replace it unless we're adding more digits
+            if (val === '0') val = key;
+            else val += key;
+        }
+
+        activeQtyInput.value = val;
+        // Trigger input event to sync state
+        activeQtyInput.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+
+    // Set up numpad listeners once
+    document.querySelectorAll('.numpad-btn').forEach(btn => {
+        const handleInteraction = (e) => {
+            e.preventDefault(); // Prevent focus loss from input
+            handleNumpadClick(btn.dataset.key);
+        };
+        btn.addEventListener('mousedown', handleInteraction);
+        btn.addEventListener('touchstart', handleInteraction, { passive: false });
+    });
+
     function createQtyStepper(item, type) {
         const group = document.createElement('div');
         group.className = `qty-stepper ${type}-stepper`;
@@ -2363,13 +2411,32 @@ document.addEventListener('DOMContentLoaded', async () => {
         const input = document.createElement('input');
         input.type = 'text';
         input.autocomplete = 'off';
-        input.inputMode = 'numeric';
+        input.inputMode = 'none'; // Suppress native keyboard
         input.className = 'qty-input';
         input.value = type === 'have' ? item.haveCount : item.wantCount;
 
         group.appendChild(input);
         applyManualSelection(input);
         input.addEventListener('contextmenu', (e) => e.preventDefault());
+
+        input.addEventListener('focus', () => {
+            activeQtyInput = input;
+            toolbarMain.classList.add('hidden');
+            toolbarNumpad.classList.remove('hidden');
+            document.body.classList.add('numpad-open');
+        });
+
+        input.addEventListener('blur', () => {
+            // Small delay to check if focus moved to another qty-input
+            setTimeout(() => {
+                if (!document.activeElement.classList.contains('qty-input')) {
+                    activeQtyInput = null;
+                    toolbarMain.classList.remove('hidden');
+                    toolbarNumpad.classList.add('hidden');
+                    document.body.classList.remove('numpad-open');
+                }
+            }, 50);
+        });
 
         input.addEventListener('input', () => {
             if (type === 'have') {
@@ -2382,18 +2449,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         input.addEventListener('keydown', (e) => {
             if (e.key === 'Enter') {
                 e.preventDefault();
-                // Find next visible qty-input
-                const allInputs = Array.from(document.querySelectorAll('.qty-input'));
-                const visibleInputs = allInputs.filter(inp => {
-                    const style = window.getComputedStyle(inp.parentElement);
-                    return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
-                });
-                const idx = visibleInputs.indexOf(input);
-                if (idx !== -1 && idx < visibleInputs.length - 1) {
-                    visibleInputs[idx + 1].focus();
-                } else {
-                    input.blur();
-                }
+                focusNextQtyInput(input);
             }
         });
 

--- a/public/index.html
+++ b/public/index.html
@@ -31,30 +31,49 @@
         </ul>
 
         <nav class="bottom-toolbar">
-            <div class="list-picker-container">
-                <div id="lists-menu" class="lists-menu" role="menu"></div>
-                <button class="list-picker-btn" id="toolbar-lists" title="Manage Lists" aria-label="Manage Lists" aria-haspopup="true">
-                    <div class="list-swatch" id="current-list-swatch" aria-hidden="true"></div>
-                    <span id="current-list-name">Loading...</span>
-                    <svg class="dropdown-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                        <path d="M6 10L12 16L18 10"></path>
-                    </svg>
-                </button>
+            <div id="toolbar-main">
+                <div class="list-picker-container">
+                    <div id="lists-menu" class="lists-menu" role="menu"></div>
+                    <button class="list-picker-btn" id="toolbar-lists" title="Manage Lists" aria-label="Manage Lists" aria-haspopup="true">
+                        <div class="list-swatch" id="current-list-swatch" aria-hidden="true"></div>
+                        <span id="current-list-name">Loading...</span>
+                        <svg class="dropdown-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M6 10L12 16L18 10"></path>
+                        </svg>
+                    </button>
+                </div>
+
+                <div class="toolbar-actions">
+                    <button class="toolbar-btn" id="toolbar-clear-shop" title="Clear Shopping Progress" aria-label="Clear Shopping Progress">
+                        <i class="fas fa-eraser" aria-hidden="true"></i>
+                    </button>
+                    <button class="toolbar-btn" id="toolbar-mode" title="Toggle Mode" aria-label="Toggle Mode">
+                        <i class="fas fa-list-check" aria-hidden="true"></i>
+                    </button>
+                    <button class="toolbar-btn" id="toolbar-reorder" title="Toggle Edit Mode" aria-label="Toggle Edit Mode">
+                        <i class="fas fa-pen" aria-hidden="true"></i>
+                    </button>
+                    <button class="toolbar-btn" id="toolbar-sync" title="Cloud Sync" aria-label="Cloud Sync">
+                        <span id="sync-icon" class="sync-icon" aria-hidden="true"></span>
+                    </button>
+                </div>
             </div>
 
-            <div class="toolbar-actions">
-                <button class="toolbar-btn" id="toolbar-clear-shop" title="Clear Shopping Progress" aria-label="Clear Shopping Progress">
-                    <i class="fas fa-eraser" aria-hidden="true"></i>
-                </button>
-                <button class="toolbar-btn" id="toolbar-mode" title="Toggle Mode" aria-label="Toggle Mode">
-                    <i class="fas fa-list-check" aria-hidden="true"></i>
-                </button>
-                <button class="toolbar-btn" id="toolbar-reorder" title="Toggle Edit Mode" aria-label="Toggle Edit Mode">
-                    <i class="fas fa-pen" aria-hidden="true"></i>
-                </button>
-                <button class="toolbar-btn" id="toolbar-sync" title="Cloud Sync" aria-label="Cloud Sync">
-                    <span id="sync-icon" class="sync-icon" aria-hidden="true"></span>
-                </button>
+            <div id="toolbar-numpad" class="hidden">
+                <div class="numpad-grid">
+                    <button class="numpad-btn" data-key="1">1</button>
+                    <button class="numpad-btn" data-key="2">2</button>
+                    <button class="numpad-btn" data-key="3">3</button>
+                    <button class="numpad-btn" data-key="4">4</button>
+                    <button class="numpad-btn" data-key="5">5</button>
+                    <button class="numpad-btn" data-key="6">6</button>
+                    <button class="numpad-btn" data-key="7">7</button>
+                    <button class="numpad-btn" data-key="8">8</button>
+                    <button class="numpad-btn" data-key="9">9</button>
+                    <button class="numpad-btn" data-key="backspace" aria-label="Backspace"><i class="fas fa-backspace"></i></button>
+                    <button class="numpad-btn" data-key="0">0</button>
+                    <button class="numpad-btn" data-key="enter" aria-label="Next or Done"><i class="fas fa-arrow-right"></i></button>
+                </div>
             </div>
         </nav>
     </div>

--- a/public/style.css
+++ b/public/style.css
@@ -1758,14 +1758,12 @@ input:checked+.slider:before {
     max-width: 460px;
     background: var(--card-bg);
     padding: 0.75rem 1rem;
-    display: grid;
-    grid-template-columns: 1fr auto;
-    align-items: center;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
     border: 1px solid var(--border-color);
     border-radius: 24px;
     z-index: 1000;
     box-sizing: border-box;
+    transition: padding 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 @media (min-width: 600px) {
@@ -1773,13 +1771,20 @@ input:checked+.slider:before {
         position: sticky;
         bottom: 1rem;
         margin: 0 auto 1rem auto;
+        transform: none;
+        left: auto;
     }
+}
+
+#toolbar-main {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    width: 100%;
 }
 
 .list-picker-container {
     position: relative;
-    justify-self: start;
-    height: 100%;
     display: flex;
     align-items: center;
 }
@@ -2053,6 +2058,57 @@ input:checked+.slider:before {
 
 .hide-drag-handles .grocery-item .left-action {
     width: 40px !important;
+}
+
+/* Numpad Styles */
+#toolbar-numpad {
+    width: 100%;
+}
+
+.numpad-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.5rem;
+}
+
+.numpad-btn {
+    height: 44px;
+    border: none;
+    background: color-mix(in srgb, var(--primary-color) 5%, var(--hover-bg));
+    color: var(--text-color);
+    border-radius: 12px;
+    font-size: 1.2rem;
+    font-weight: 700;
+    font-family: inherit;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.1s cubic-bezier(0.4, 0, 0.2, 1);
+    -webkit-tap-highlight-color: transparent;
+    user-select: none;
+}
+
+.numpad-btn:active {
+    background: color-mix(in srgb, var(--primary-color) 20%, var(--hover-bg));
+    transform: scale(0.92);
+}
+
+.numpad-btn[data-key="backspace"] {
+    color: var(--danger-color);
+}
+
+.numpad-btn[data-key="enter"] {
+    background: var(--primary-color);
+    color: white;
+}
+
+.numpad-btn i {
+    pointer-events: none;
+}
+
+.numpad-open .grocery-list {
+    padding-bottom: 280px;
 }
 
 


### PR DESCRIPTION
This PR introduces a custom in-app numpad for entering quantities, addressing the issue of layout shifts (screen jumping) caused by the native mobile keyboard.

### Key Changes:
- **HTML**: Added `#toolbar-main` and `#toolbar-numpad` containers within the `.bottom-toolbar`.
- **CSS**: Styled the numpad grid and buttons to match the app's aesthetic. Implemented transitions for a smooth swap between the main toolbar and the numpad.
- **JS**: 
    - Set `inputMode = 'none'` for quantity inputs.
    - Added focus/blur listeners to toggle the toolbar state.
    - Implemented `handleNumpadClick` to manage digit entry, backspace (with "0" replacement logic), and "Enter" for navigation.
    - Used `mousedown` and `touchstart` with `preventDefault()` on numpad buttons to maintain input focus.

Verified with Playwright tests and visual inspection.

Fixes #323

---
*PR created automatically by Jules for task [16820044764586602726](https://jules.google.com/task/16820044764586602726) started by @camyoung1234*