### PR TITLE
True Black Live Preview

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1204,6 +1204,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             selectTheme(initialTheme || 'var(--theme-blue)');
             selectAccent(initialAccent || 'var(--theme-amber)');
             trueBlackToggle.checked = !!initialTrueBlack;
+            document.documentElement.classList.toggle('true-black', !!initialTrueBlack);
         } else {
             modalDisplayGroup.classList.add('hidden');
             modalThemeGroup.classList.add('hidden');
@@ -1242,6 +1243,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             currentDeleteActionCallback();
         }
         hideModal();
+    });
+
+    trueBlackToggle.addEventListener('change', () => {
+        document.documentElement.classList.toggle('true-black', trueBlackToggle.checked);
     });
 
     modalSaveBtn.addEventListener('click', () => {


### PR DESCRIPTION
Implemented live preview for the "True Black" toggle in the list settings modal. The 'true-black' CSS class is now added or removed from the root element immediately when the checkbox is toggled, matching the behavior of theme and accent color selections. Also ensured the initial state is correctly reflected when opening the modal and restored if the modal is canceled.

Fixes #322

---
*PR created automatically by Jules for task [18402958037295914055](https://jules.google.com/task/18402958037295914055) started by @camyoung1234*