### PR TITLE
Add transition from bottom toolbar to keyboard

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -64,6 +64,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const groceryList = document.getElementById('grocery-list');
     const appContainer = document.querySelector('.app-container');
     const listsMenu = document.getElementById('lists-menu');
+    const bottomToolbar = document.querySelector('.bottom-toolbar');
     const toolbarMain = document.getElementById('toolbar-main');
     const toolbarNumpad = document.getElementById('toolbar-numpad');
 
@@ -2426,8 +2427,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         input.addEventListener('focus', () => {
             activeQtyInput = input;
-            toolbarMain.classList.add('hidden');
-            toolbarNumpad.classList.remove('hidden');
+            bottomToolbar.classList.add('numpad-active');
             document.body.classList.add('numpad-open');
         });
 
@@ -2436,8 +2436,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             setTimeout(() => {
                 if (!document.activeElement.classList.contains('qty-input')) {
                     activeQtyInput = null;
-                    toolbarMain.classList.remove('hidden');
-                    toolbarNumpad.classList.add('hidden');
+                    bottomToolbar.classList.remove('numpad-active');
                     document.body.classList.remove('numpad-open');
                 }
             }, 50);

--- a/public/index.html
+++ b/public/index.html
@@ -59,7 +59,7 @@
                 </div>
             </div>
 
-            <div id="toolbar-numpad" class="hidden">
+            <div id="toolbar-numpad">
                 <div class="numpad-grid">
                     <button class="numpad-btn" data-key="1">1</button>
                     <button class="numpad-btn" data-key="2">2</button>

--- a/public/style.css
+++ b/public/style.css
@@ -1766,6 +1766,8 @@ input:checked+.slider:before {
     box-sizing: border-box;
     transition: padding 0.4s cubic-bezier(0.4, 0, 0.2, 1), transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     overflow: hidden;
+    display: grid;
+    align-items: center;
 }
 
 @media (min-width: 600px) {
@@ -1779,20 +1781,23 @@ input:checked+.slider:before {
 }
 
 #toolbar-main {
+    grid-area: 1 / 1;
     display: grid;
     grid-template-columns: 1fr auto;
     align-items: center;
     width: 100%;
-    transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1), max-height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1), max-height 0.4s cubic-bezier(0.4, 0, 0.2, 1), visibility 0.4s;
     max-height: 100px;
     opacity: 1;
+    overflow: hidden;
+    visibility: visible;
 }
 
 .bottom-toolbar.numpad-active #toolbar-main {
     max-height: 0;
     opacity: 0;
-    transform: translateY(-20px);
     pointer-events: none;
+    visibility: hidden;
 }
 
 .list-picker-container {
@@ -2074,19 +2079,21 @@ input:checked+.slider:before {
 
 /* Numpad Styles */
 #toolbar-numpad {
+    grid-area: 1 / 1;
     width: 100%;
-    transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1), max-height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1), max-height 0.4s cubic-bezier(0.4, 0, 0.2, 1), visibility 0.4s;
     max-height: 0;
     opacity: 0;
-    transform: translateY(20px);
     pointer-events: none;
+    overflow: hidden;
+    visibility: hidden;
 }
 
 .bottom-toolbar.numpad-active #toolbar-numpad {
     max-height: 300px;
     opacity: 1;
-    transform: translateY(0);
     pointer-events: auto;
+    visibility: visible;
 }
 
 .numpad-grid {

--- a/public/style.css
+++ b/public/style.css
@@ -357,6 +357,7 @@ h1 {
     margin: 0;
     flex: 1;
     padding-bottom: 120px;
+    transition: padding-bottom 0.4s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /* Swipe slide transition (Retained for potential legacy use) */
@@ -1763,7 +1764,8 @@ input:checked+.slider:before {
     border-radius: 24px;
     z-index: 1000;
     box-sizing: border-box;
-    transition: padding 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: padding 0.4s cubic-bezier(0.4, 0, 0.2, 1), transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    overflow: hidden;
 }
 
 @media (min-width: 600px) {
@@ -1781,6 +1783,16 @@ input:checked+.slider:before {
     grid-template-columns: 1fr auto;
     align-items: center;
     width: 100%;
+    transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1), max-height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    max-height: 100px;
+    opacity: 1;
+}
+
+.bottom-toolbar.numpad-active #toolbar-main {
+    max-height: 0;
+    opacity: 0;
+    transform: translateY(-20px);
+    pointer-events: none;
 }
 
 .list-picker-container {
@@ -2063,6 +2075,18 @@ input:checked+.slider:before {
 /* Numpad Styles */
 #toolbar-numpad {
     width: 100%;
+    transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1), max-height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    max-height: 0;
+    opacity: 0;
+    transform: translateY(20px);
+    pointer-events: none;
+}
+
+.bottom-toolbar.numpad-active #toolbar-numpad {
+    max-height: 300px;
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
 }
 
 .numpad-grid {


### PR DESCRIPTION
Implemented a smooth transition between the main bottom toolbar and the custom numpad keyboard. When a quantity input is focused, the toolbar now expands upward to reveal the numpad while the main actions fade out. When blurred, it collapses back down. This was achieved by moving visibility logic from JS 'hidden' classes to a CSS class 'numpad-active' on the toolbar container, paired with CSS transitions on max-height, opacity, and transform.

Fixes #328

---
*PR created automatically by Jules for task [11996488527964017835](https://jules.google.com/task/11996488527964017835) started by @camyoung1234*