### PR TITLE
Prevent overscrolling on Android

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1,4 +1,7 @@
-html { scroll-behavior: smooth; }
+html {
+    scroll-behavior: smooth;
+    overscroll-behavior: none;
+}
 * {
     box-sizing: border-box;
 }
@@ -161,6 +164,7 @@ body {
         height: fit-content;
         max-height: 90vh;
         overflow-y: auto;
+        overscroll-behavior: none;
     }
 }
 
@@ -909,6 +913,7 @@ h1 {
     min-width: 120px;
     max-height: 150px;
     overflow-y: auto;
+    overscroll-behavior: none;
     z-index: 100;
     /* Ensure it appears above other elements */
     animation: dropdownPop 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
@@ -1276,6 +1281,7 @@ input:checked+.slider:before {
     z-index: 1001;
     max-height: 200px;
     overflow-y: auto;
+    overscroll-behavior: none;
     display: none;
 }
 
@@ -1922,6 +1928,7 @@ input:checked+.slider:before {
     padding: 0.5rem 0;
     max-height: 50vh;
     overflow-y: auto;
+    overscroll-behavior: none;
     z-index: 2000;
     opacity: 0;
     pointer-events: none;


### PR DESCRIPTION
This PR prevents the Android "stretch" or "bounce" effect when scrolling past the boundaries of the page or its scrollable menus. It uses the `overscroll-behavior: none` CSS property on the root `html` element and all major scrollable containers in the application.

Fixes #333

---
*PR created automatically by Jules for task [18437551684545541876](https://jules.google.com/task/18437551684545541876) started by @camyoung1234*