### PR TITLE
Animate numpad keyboard usage and theme backspace button

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2404,10 +2404,18 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.querySelectorAll('.numpad-btn').forEach(btn => {
         const handleInteraction = (e) => {
             e.preventDefault(); // Prevent focus loss from input
+            btn.classList.add('pressed');
             handleNumpadClick(btn.dataset.key);
+        };
+        const endInteraction = () => {
+            btn.classList.remove('pressed');
         };
         btn.addEventListener('mousedown', handleInteraction);
         btn.addEventListener('touchstart', handleInteraction, { passive: false });
+        btn.addEventListener('mouseup', endInteraction);
+        btn.addEventListener('mouseleave', endInteraction);
+        btn.addEventListener('touchend', endInteraction);
+        btn.addEventListener('touchcancel', endInteraction);
     });
 
     function createQtyStepper(item, type) {

--- a/public/style.css
+++ b/public/style.css
@@ -2127,13 +2127,17 @@ input:checked+.slider:before {
     user-select: none;
 }
 
-.numpad-btn:active {
-    background: color-mix(in srgb, var(--primary-color) 20%, var(--hover-bg));
-    transform: scale(0.92);
+.numpad-btn:active,
+.numpad-btn.pressed {
+    background: var(--primary-color) !important;
+    color: white !important;
+    transform: scale(1.15);
+    z-index: 10;
+    transition: all 0.05s ease-out;
 }
 
 .numpad-btn[data-key="backspace"] {
-    color: var(--danger-color);
+    color: var(--primary-color);
 }
 
 .numpad-btn[data-key="enter"] {


### PR DESCRIPTION
This change enhances the user experience when using the custom numpad keyboard. 

### Changes:
- **Themed Backspace:** The backspace button now uses the application's primary theme color instead of the danger color, creating a more cohesive look.
- **Pop Animation:** Numpad buttons now "pop" when pressed. They scale up slightly (`1.15x`) and change their background to the primary theme color with white text.
- **Improved Interaction Logic:** Added JavaScript event listeners (`mousedown`, `touchstart`, `mouseup`, `touchend`, etc.) to reliably toggle a `.pressed` class, ensuring visual feedback is responsive on both desktop and mobile devices.
- **Snappy Transitions:** Added a quick `0.05s` transition to the pressed state for a responsive, tactile feel.
- **Performance Optimized:** The animation uses `transform: scale()` instead of font-size changes to avoid expensive layout reflows.

Fixes #336

---
*PR created automatically by Jules for task [61523482366658316](https://jules.google.com/task/61523482366658316) started by @camyoung1234*