### PR TITLE
Custom Quantity Inputs with Replace-on-Focus Logic

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -234,7 +234,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     });
 
-    groceryList.addEventListener('focusin', (e) => {
+    groceryList.addEventListener('focus', (e) => {
         if (e.target.classList.contains('qty-input')) {
             // Deactivate any item controls
             groceryList.querySelectorAll('.grocery-item.show-controls').forEach(el => el.classList.remove('show-controls'));
@@ -252,11 +252,14 @@ document.addEventListener('DOMContentLoaded', async () => {
                 // If blur caused a re-render (which it does via saveName), restore focus
                 if (focusedId && (!e.target.isConnected || document.activeElement !== e.target)) {
                     const newInput = document.querySelector(`.grocery-item[data-id="${focusedId}"] .${wasType}-stepper .qty-input`);
-                    if (newInput) newInput.focus();
+                    if (newInput) {
+                        newInput.focus();
+                        newInput.dataset.isFresh = 'true';
+                    }
                 }
             }
         }
-    });
+    }, true);
 
     groceryList.addEventListener('submit', (e) => {
         const target = e.target;
@@ -456,7 +459,15 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
         });
         input.addEventListener('focus', () => {
-            input.setSelectionRange(0, input.value.length);
+            if (input.tagName === 'INPUT' || input.tagName === 'TEXTAREA') {
+                input.setSelectionRange(0, input.value.length);
+            } else {
+                const range = document.createRange();
+                range.selectNodeContents(input);
+                const selection = window.getSelection();
+                selection.removeAllRanges();
+                selection.addRange(range);
+            }
         });
     };
 
@@ -1908,7 +1919,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (stepper) {
                 const input = stepper.querySelector('.qty-input');
                 if (input) {
-                    input.value = item.haveCount;
+                    if (input.tagName === 'INPUT') input.value = item.haveCount;
+                    else input.textContent = item.haveCount;
                     input.classList.remove('pop-animate');
                     void input.offsetWidth;
                     input.classList.add('pop-animate');
@@ -1933,7 +1945,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 if (stepper) {
                     const input = stepper.querySelector('.qty-input');
                     if (input) {
-                        input.value = i.wantCount;
+                        if (input.tagName === 'INPUT') input.value = i.wantCount;
+                        else input.textContent = i.wantCount;
                         input.classList.remove('pop-animate');
                         void input.offsetWidth;
                         input.classList.add('pop-animate');
@@ -2369,8 +2382,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     function focusNextQtyInput(currentInput) {
         const allInputs = Array.from(document.querySelectorAll('.qty-input'));
         const visibleInputs = allInputs.filter(inp => {
-            const style = window.getComputedStyle(inp.parentElement);
-            return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+            const parent = inp.parentElement;
+            // Check if element or its parent is hidden
+            return parent && parent.offsetParent !== null && window.getComputedStyle(parent).visibility !== 'hidden';
         });
         const idx = visibleInputs.indexOf(currentInput);
         if (idx !== -1 && idx < visibleInputs.length - 1) {
@@ -2383,19 +2397,28 @@ document.addEventListener('DOMContentLoaded', async () => {
     function handleNumpadClick(key) {
         if (!activeQtyInput) return;
 
-        let val = activeQtyInput.value;
+        let val = activeQtyInput.tagName === 'INPUT' ? activeQtyInput.value : activeQtyInput.textContent;
+        const isFresh = activeQtyInput.dataset.isFresh === 'true';
+
         if (key === 'backspace') {
-            val = val.slice(0, -1);
+            if (isFresh) {
+                val = '';
+            } else {
+                val = val.slice(0, -1);
+            }
         } else if (key === 'enter') {
             focusNextQtyInput(activeQtyInput);
             return;
         } else {
-            // If value is currently "0", replace it unless we're adding more digits
-            if (val === '0') val = key;
+            // If value is currently "0" or it's fresh, replace it unless we're adding more digits
+            if (val === '0' || isFresh) val = key;
             else val += key;
         }
 
-        activeQtyInput.value = val;
+        activeQtyInput.dataset.isFresh = 'false';
+        if (activeQtyInput.tagName === 'INPUT') activeQtyInput.value = val;
+        else activeQtyInput.textContent = val;
+
         // Trigger input event to sync state
         activeQtyInput.dispatchEvent(new Event('input', { bubbles: true }));
     }
@@ -2414,18 +2437,18 @@ document.addEventListener('DOMContentLoaded', async () => {
         const group = document.createElement('div');
         group.className = `qty-stepper ${type}-stepper`;
 
-        const input = document.createElement('input');
-        input.type = 'text';
-        input.autocomplete = 'off';
-        input.inputMode = 'none'; // Suppress native keyboard
+        const input = document.createElement('div');
         input.className = 'qty-input';
-        input.value = type === 'have' ? item.haveCount : item.wantCount;
+        input.tabIndex = 0;
+        input.role = 'textbox';
+        input.textContent = type === 'have' ? item.haveCount : item.wantCount;
 
         group.appendChild(input);
         applyManualSelection(input);
         input.addEventListener('contextmenu', (e) => e.preventDefault());
 
-        input.addEventListener('focus', () => {
+        const handleFocus = () => {
+            input.dataset.isFresh = 'true';
             activeQtyInput = input;
             bottomToolbar.classList.add('numpad-active');
             document.body.classList.add('numpad-open');
@@ -2434,12 +2457,17 @@ document.addEventListener('DOMContentLoaded', async () => {
             setTimeout(() => {
                 input.scrollIntoView({ behavior: 'smooth', block: 'center' });
             }, 150);
+        };
+
+        input.addEventListener('focus', handleFocus);
+        input.addEventListener('click', () => {
+            input.dataset.isFresh = 'true';
         });
 
         input.addEventListener('blur', () => {
             // Small delay to check if focus moved to another qty-input
             setTimeout(() => {
-                if (!document.activeElement.classList.contains('qty-input')) {
+                if (!document.activeElement || !document.activeElement.classList.contains('qty-input')) {
                     activeQtyInput = null;
                     bottomToolbar.classList.remove('numpad-active');
                     document.body.classList.remove('numpad-open');
@@ -2448,10 +2476,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
 
         input.addEventListener('input', () => {
+            const val = input.textContent;
             if (type === 'have') {
-                setHave(item.id, input.value);
+                setHave(item.id, val);
             } else {
-                setWant(item.id, input.value);
+                setWant(item.id, val);
             }
         });
 
@@ -2459,6 +2488,12 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (e.key === 'Enter') {
                 e.preventDefault();
                 focusNextQtyInput(input);
+            } else if (e.key === 'Backspace') {
+                e.preventDefault();
+                handleNumpadClick('backspace');
+            } else if (/^[0-9]$/.test(e.key)) {
+                e.preventDefault();
+                handleNumpadClick(e.key);
             }
         });
 

--- a/public/style.css
+++ b/public/style.css
@@ -992,6 +992,9 @@ h1 {
     border-radius: 8px;
     background: var(--input-bg);
     color: var(--text-color);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     text-align: center;
     font-size: 1rem;
     font-weight: 700;
@@ -1000,6 +1003,7 @@ h1 {
     transition: border-color var(--transition);
     box-sizing: border-box;
     -moz-appearance: textfield;
+    cursor: text;
 }
 
 .qty-input::-webkit-outer-spin-button,

--- a/tests/shared_want.spec.js
+++ b/tests/shared_want.spec.js
@@ -60,10 +60,11 @@ test('Shared wantCount synchronizes across items with same name', async ({ page 
 
   const firstBanana = bananaRows.first();
   const wantInput = firstBanana.locator('.want-stepper .qty-input');
-  await wantInput.fill('2');
-  await wantInput.press('Enter');
+  await wantInput.click();
+  await page.keyboard.type('2');
+  await page.keyboard.press('Enter');
 
-  await expect(bananaRows.first().locator('.want-stepper .qty-input')).toHaveValue('2');
+  await expect(bananaRows.first().locator('.want-stepper .qty-input')).toHaveText('2');
 
   // Switch back to Home Mode to add another item
   await page.click('#toolbar-mode');
@@ -80,7 +81,7 @@ test('Shared wantCount synchronizes across items with same name', async ({ page 
   await page.click('#toolbar-mode');
   await expect(page.locator('.app-container')).toHaveClass(/shop-mode/);
   await expect(page.locator('.grocery-item:has-text("Bananas")')).toHaveCount(1);
-  await expect(page.locator('.grocery-item:has-text("Bananas")').locator('.want-stepper .qty-input')).toHaveValue('2');
+  await expect(page.locator('.grocery-item:has-text("Bananas")').locator('.want-stepper .qty-input')).toHaveText('2');
 });
 
 test('Shop mode groups items with shared wantCount correctly', async ({ page }) => {
@@ -247,5 +248,5 @@ test('Renaming an item to an existing name syncs wantCount', async ({ page }) =>
     await expect(page.locator('.app-container')).toHaveClass(/shop-mode/);
     const appleGroup = page.locator('.grocery-item:has-text("Apples")');
     await expect(appleGroup).toHaveCount(1);
-    await expect(appleGroup.locator('.want-stepper .qty-input')).toHaveValue('10');
+    await expect(appleGroup.locator('.want-stepper .qty-input')).toHaveText('10');
 });

--- a/tests/shop_stepper.spec.js
+++ b/tests/shop_stepper.spec.js
@@ -38,19 +38,22 @@ await page.addInitScript(() => { localStorage.setItem('grocery-logged-in', 'true
     // Verify input exists
     const wantInput = page.locator('.want-stepper .qty-input');
     await expect(wantInput).toBeVisible();
-    await expect(wantInput).toHaveValue('1');
+    await expect(wantInput).toHaveText('1');
 
     // Change value
-    await wantInput.fill('2');
-    await expect(wantInput).toHaveValue('2');
+    await wantInput.click();
+    await page.keyboard.type('2');
+    await expect(wantInput).toHaveText('2');
 
     // Verify shop qty circle also updated
     const circleNum = page.locator('.shop-check-area .qty-number');
     await expect(circleNum).toHaveText('2');
 
     // Change back
-    await wantInput.fill('1');
-    await expect(wantInput).toHaveValue('1');
+    await wantInput.click();
+    await page.keyboard.press('Backspace');
+    await page.keyboard.type('1');
+    await expect(wantInput).toHaveText('1');
     await expect(circleNum).toHaveText('1');
 
     // Exit Edit Mode and verify controls are hidden


### PR DESCRIPTION
This change replaces the native input elements used for item quantities with custom 'div' elements. This allows for better control over the input behavior, specifically implementing a requirement where the first digit typed after focusing an input replaces its previous value.

Key changes:
- In 'public/app.js', 'createQtyStepper' now creates a 'div' with 'tabindex="0"'.
- State setters ('setHave', 'setWant') and the numpad handler ('handleNumpadClick') were updated to use 'textContent' instead of 'value'.
- A 'dataset.isFresh' flag is used to track when an input has just been focused to trigger the replacement logic.
- 'applyManualSelection' now uses the Selection API ('Range' and 'getSelection') to select text in 'div' elements.
- 'public/style.css' was updated to ensure the 'div' version of '.qty-input' looks and behaves like the previous 'input' version.
- 'tests/shop_stepper.spec.js' and 'tests/shared_want.spec.js' were updated to accommodate the change from 'value' to 'textContent' and from '.fill()' to '.click()' plus '.keyboard.type()'.

Fixes #335

---
*PR created automatically by Jules for task [18211629606282053445](https://jules.google.com/task/18211629606282053445) started by @camyoung1234*