### PR TITLE
restyle quantity input fields

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -988,19 +988,17 @@ h1 {
 .qty-input {
     width: 48px;
     height: 32px;
-    border: 2px solid transparent;
-    border-radius: 8px;
-    background: var(--input-bg);
+    border: none;
+    background: transparent;
     color: var(--text-color);
     display: inline-flex;
     align-items: center;
     justify-content: center;
     text-align: center;
-    font-size: 1rem;
+    font-size: 1.2rem;
     font-weight: 700;
     font-family: inherit;
     outline: none;
-    transition: border-color var(--transition);
     box-sizing: border-box;
     -moz-appearance: textfield;
     cursor: text;
@@ -1013,7 +1011,7 @@ h1 {
 }
 
 .qty-input:focus {
-    border-color: var(--primary-color);
+    color: var(--primary-color);
 }
 
 .qty-input::selection {
@@ -2415,7 +2413,6 @@ input:checked+.slider:before {
     }
 }
 
-.qty-input:focus,
 .inline-item-input:focus,
 .inline-edit-input:focus,
 .inline-section-input:focus,


### PR DESCRIPTION
Updated the styling of the quantity input fields to be cleaner and more consistent with the checklist quantities. Borders and backgrounds were removed, font size was increased, and focus is now indicated by changing the text color to the primary theme color.

Fixes #339

---
*PR created automatically by Jules for task [12649958155969917933](https://jules.google.com/task/12649958155969917933) started by @camyoung1234*