### PR TITLE
Display section names in variable size caps

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -339,6 +339,7 @@ h1 {
 .add-section-input {
     font-size: 1.2rem;
     font-weight: 700;
+    font-variant: small-caps;
     padding: 0 !important;
     line-height: 1;
     margin: 0;
@@ -1464,6 +1465,7 @@ input:checked+.slider:before {
 .section-title {
     font-size: 1.2rem;
     font-weight: 700;
+    font-variant: small-caps;
     margin: 0;
     color: var(--text-color);
     cursor: pointer;
@@ -1484,6 +1486,7 @@ input:checked+.slider:before {
     font-family: inherit;
     font-size: 1.2rem;
     font-weight: 700;
+    font-variant: small-caps;
     color: var(--text-color);
     background: transparent;
     border: 1px solid var(--primary-color);


### PR DESCRIPTION
Applied 'font-variant: small-caps' to section titles and related input fields to render section names with all capital letters, where originally lowercase letters retain a shorter height. This affects the section display, the inline edit input, and the 'Add Section' input field.

Fixes #345

---
*PR created automatically by Jules for task [3058135338101127258](https://jules.google.com/task/3058135338101127258) started by @camyoung1234*