### PR TITLE
Move Home Mode quantities to the left side

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2326,8 +2326,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 
                 if (isHome) {
                     li.innerHTML = `<div class="left-action"><div class="drag-handle" draggable="true"><i class="fas fa-grip-vertical"></i></div></div><div class="item-info"><span class="item-text">${escapeHTML(item.text)}</span></div><div class="quantity-controls"></div><button class="item-delete-btn" aria-label="Delete item"><i class="fas fa-times"></i></button>`;
-                    const controls = li.querySelector('.quantity-controls');
-                    controls.appendChild(createQtyStepper(item, 'have'));
+                    const leftAction = li.querySelector('.left-action');
+                    leftAction.appendChild(createQtyStepper(item, 'have'));
                 } else {
                     const toBuy = Math.max(0, item.wantCount - item.haveCount);
                     li.innerHTML = `<div class="left-action"><div class="drag-handle" draggable="true"><i class="fas fa-grip-vertical"></i></div><div class="shop-check-area"><span class="qty-number">${toBuy}</span><svg class="check-svg" viewBox="0 0 24 24"><path class="check-path" d="M4 12l5 5L20 6" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg></div></div><div class="item-info"><span class="item-text">${escapeHTML(item.text)}</span></div><div class="quantity-controls"></div>`;

--- a/public/style.css
+++ b/public/style.css
@@ -513,6 +513,19 @@ h1 {
     min-width: 48px;
     /* Fix width to enable transition */
     opacity: 1;
+}
+
+.home-mode:not(.hide-drag-handles) .quantity-controls {
+    width: 0;
+    min-width: 0;
+}
+
+/* Home mode stepper is on the left now, but we must ensure it doesn't overlap text when hidden */
+.home-mode .left-action {
+    z-index: 210;
+}
+
+.quantity-controls {
     overflow: visible;
     position: relative;
     z-index: 200;
@@ -979,6 +992,24 @@ h1 {
 
 .home-mode.hide-drag-handles .have-stepper {
     display: flex;
+}
+
+.left-action .have-stepper {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) scale(0.5);
+    opacity: 0;
+    visibility: hidden;
+    transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    pointer-events: none;
+}
+
+.hide-drag-handles .left-action .have-stepper {
+    opacity: 1;
+    visibility: visible;
+    transform: translate(-50%, -50%) scale(1);
+    pointer-events: auto;
 }
 
 .shop-mode:not(.hide-drag-handles) .want-stepper {
@@ -2027,7 +2058,8 @@ input:checked+.slider:before {
     visibility: visible !important;
 }
 
-.grocery-item.show-controls .quantity-controls {
+.grocery-item.show-controls .quantity-controls,
+.grocery-item.show-controls .have-stepper {
     opacity: 0 !important;
     pointer-events: none !important;
     visibility: hidden !important;
@@ -2381,7 +2413,9 @@ input:checked+.slider:before {
 .home-mode:not(.hide-drag-handles) .grocery-item .quantity-controls,
 .touch-ghost.home-mode:not(.hide-drag-handles) .quantity-controls,
 .shop-mode.hide-drag-handles .grocery-item .quantity-controls,
-.touch-ghost.shop-mode.hide-drag-handles .quantity-controls {
+.touch-ghost.shop-mode.hide-drag-handles .quantity-controls,
+.home-mode:not(.hide-drag-handles) .grocery-item .have-stepper,
+.touch-ghost.home-mode:not(.hide-drag-handles) .have-stepper {
     opacity: 0;
     pointer-events: none;
     visibility: hidden;
@@ -2458,7 +2492,8 @@ input:checked+.slider:before {
 .is-dragging .move-here-btn {
     }
 
-.is-dragging .quantity-controls {
+.is-dragging .quantity-controls,
+.is-dragging .have-stepper {
     opacity: 1 !important;
     pointer-events: auto !important;
     visibility: visible !important;
@@ -2484,6 +2519,7 @@ input:checked+.slider:before {
 .is-dragging .section-header,
 .is-dragging .section-container,
 .is-dragging .quantity-controls,
+.is-dragging .have-stepper,
 .is-dragging .drag-handle,
 .is-dragging .item-delete-btn,
 .is-dragging .section-actions,


### PR DESCRIPTION
Moved the "have" quantity stepper in Home Mode from the right side of the item row to the left side (.left-action container). This aligns the Home Mode UI with Store Mode, where the "buy" quantity is also displayed on the left. The change includes CSS updates to handle absolute centering within the left action area and coordinated visibility with drag handles and delete buttons.

Fixes #351

---
*PR created automatically by Jules for task [5031138094883037063](https://jules.google.com/task/5031138094883037063) started by @camyoung1234*