### PR TITLE
Indent items in store mode

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -527,7 +527,7 @@ h1 {
 
 /* Shop Mode Content */
 .section-items-list.shop-mode {
-    padding-left: 0;
+    padding-left: 1rem;
     display: flex;
     flex-direction: column;
     gap: 0;

--- a/tests/indentation.test.js
+++ b/tests/indentation.test.js
@@ -2,6 +2,8 @@ const { mockFirebase, setMockState } = require('./mockFirebase');
 const { test, expect } = require('@playwright/test');
 
 test('verify indentation behavior', async ({ page }) => {
+  await mockFirebase(page);
+  await page.goto('/');
 
   await page.waitForSelector('.bottom-toolbar');
 
@@ -99,6 +101,7 @@ await setMockState(page, { ...state, mode: 'home', editMode: true });
 
   console.log(`Shop Edit ON - Section Title X: ${shopSectionX_EditOn}, Item Text X: ${shopItemX_EditOn}`);
 
-  // Both should align when editing (drag handles visible)
-  expect(Math.abs(shopSectionX_EditOn - shopItemX_EditOn)).toBeLessThanOrEqual(1);
+  // Shop items should be indented even in edit mode (1rem = 16px)
+  expect(shopItemX_EditOn).toBeGreaterThan(shopSectionX_EditOn);
+  expect(Math.abs(shopItemX_EditOn - shopSectionX_EditOn - 16)).toBeLessThanOrEqual(2);
 });


### PR DESCRIPTION
Added indentation to grocery items in store (shop) mode to improve visual hierarchy and make it easier to distinguish items from section headers (aisles). Updated the automated test suite to reflect this intentional layout change.

Fixes #357

---
*PR created automatically by Jules for task [16536951969668471874](https://jules.google.com/task/16536951969668471874) started by @camyoung1234*