### PR TITLE
Prevent item name overflow using variable font width adjustment

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2375,6 +2375,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         groceryList.querySelectorAll('.add-item-input, .add-section-input').forEach(applyManualSelection);
 
         newlyDeletedIds.clear();
+        adjustItemFontWidths();
     }
 
     let activeQtyInput = null;
@@ -3108,6 +3109,45 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     groceryList.addEventListener('dragend', handleDragEnd);
 
+    function adjustItemFontWidths() {
+        const itemTexts = groceryList.querySelectorAll('.item-text');
+        itemTexts.forEach(itemText => {
+            const itemInfo = itemText.closest('.item-info');
+            if (!itemInfo || itemText.closest('.undo-row')) return;
+
+            // Use getComputedStyle to ensure we have the most accurate layout info
+            const style = window.getComputedStyle(itemText);
+            if (style.display === 'none' || style.visibility === 'hidden') return;
+
+            // Reset to default to measure natural width
+            itemText.style.fontVariationSettings = "'wdth' 100";
+
+            // Use getBoundingClientRect for more precision if clientWidth is rounding
+            const containerWidth = itemInfo.getBoundingClientRect().width;
+
+            // Check if it actually overflows
+            if (itemText.scrollWidth <= containerWidth + 0.5) return;
+
+            // Binary search for the largest wdth (25-100) that fits
+            let low = 25;
+            let high = 100;
+            let optimalWidth = 25;
+
+            while (low <= high) {
+                const mid = Math.floor((low + high) / 2);
+                itemText.style.fontVariationSettings = `'wdth' ${mid}`;
+                // Using a small epsilon for subpixel layout issues
+                if (itemText.scrollWidth <= containerWidth + 0.5) {
+                    optimalWidth = mid;
+                    low = mid + 1;
+                } else {
+                    high = mid - 1;
+                }
+            }
+            itemText.style.fontVariationSettings = `'wdth' ${optimalWidth}`;
+        });
+    }
+
     function updateOrderInState(movedId, anchorId, targetSectionId, isAtEnd) {
         const currentList = getCurrentList();
         const isHome = currentMode === 'home';
@@ -3175,6 +3215,11 @@ document.addEventListener('DOMContentLoaded', async () => {
             newSectionItems.forEach((item, idx) => { item[indexKey] = idx; });
         }
     }
+
+    const resizeObserver = new ResizeObserver(() => {
+        adjustItemFontWidths();
+    });
+    resizeObserver.observe(groceryList);
 
     init();
 });

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
         integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg=="
         crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Flex:wght@100..1000&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Flex:wght,wdth@100..1000,25..150&display=swap" rel="stylesheet">
 
     <!-- PWA & Mobile Install Tags -->
     <link rel="manifest" href="/manifest.json">

--- a/public/style.css
+++ b/public/style.css
@@ -759,6 +759,10 @@ h1 {
     padding: 0;
     flex-shrink: 1;
     min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: clip;
+    font-variation-settings: 'wdth' 100;
 }
 
 
@@ -2385,6 +2389,8 @@ input:checked+.slider:before {
     opacity: 0;
     pointer-events: none;
     visibility: hidden;
+    width: 0;
+    min-width: 0;
     }
 
 


### PR DESCRIPTION
I have implemented a dynamic font-width adjustment feature for grocery item names to prevent them from wrapping to a second line. 

Key changes:
1.  **Google Fonts Update**: Modified the `Google Sans Flex` import in `index.html` to include the `wdth` axis.
2.  **CSS Refinement**: Updated `.item-text` in `style.css` to prevent text wrapping (`white-space: nowrap`) and set the default `wdth` axis to 100. I also ensured that hidden `.quantity-controls` have `width: 0` to provide accurate measurement space for the text fitting logic.
3.  **Dynamic Fitting Logic**: Added `adjustItemFontWidths()` in `app.js`. This function performs a binary search on the font's `wdth` axis (between 25 and 100) for any overflowing item name, finding the widest version that fits on a single line.
4.  **Lifecycle Integration**: The fitting logic is triggered automatically after the list is rendered and whenever the list container changes size (using a `ResizeObserver`).

I verified the solution using Playwright tests and custom scripts to ensure names shrink appropriately on narrow screens and maintain maximum width on larger ones.

Fixes #356

---
*PR created automatically by Jules for task [14064812993261382416](https://jules.google.com/task/14064812993261382416) started by @camyoung1234*