### PR TITLE
Hide 0 quantity to buy items in store mode

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -948,6 +948,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             editMode = !editMode;
             saveMode();
             updateModeUI();
+            renderList();
 
             // Maintain scroll position for the top row
             if (topRow) {
@@ -1940,27 +1941,31 @@ document.addEventListener('DOMContentLoaded', async () => {
             sameNameItems.forEach(i => i.wantCount = newWant);
             saveAppState();
 
-            sameNameItems.forEach(i => {
-                const stepper = document.querySelector(`.grocery-item[data-id="${i.id}"] .want-stepper`);
-                if (stepper) {
-                    const input = stepper.querySelector('.qty-input');
-                    if (input) {
-                        if (input.tagName === 'INPUT') input.value = i.wantCount;
-                        else input.textContent = i.wantCount;
-                        input.classList.remove('pop-animate');
-                        void input.offsetWidth;
-                        input.classList.add('pop-animate');
+            if (currentMode === 'shop' && !editMode) {
+                renderList();
+            } else {
+                sameNameItems.forEach(i => {
+                    const stepper = document.querySelector(`.grocery-item[data-id="${i.id}"] .want-stepper`);
+                    if (stepper) {
+                        const input = stepper.querySelector('.qty-input');
+                        if (input) {
+                            if (input.tagName === 'INPUT') input.value = i.wantCount;
+                            else input.textContent = i.wantCount;
+                            input.classList.remove('pop-animate');
+                            void input.offsetWidth;
+                            input.classList.add('pop-animate');
+                        }
                     }
-                }
-                const circle = document.querySelector(`.grocery-item[data-id="${i.id}"] .shop-check-area`);
-                if (circle) {
-                    const qtyNum = circle.querySelector('.qty-number');
-                    if (qtyNum) {
-                        const toBuy = Math.max(0, i.wantCount - i.haveCount);
-                        qtyNum.textContent = toBuy;
+                    const circle = document.querySelector(`.grocery-item[data-id="${i.id}"] .shop-check-area`);
+                    if (circle) {
+                        const qtyNum = circle.querySelector('.qty-number');
+                        if (qtyNum) {
+                            const toBuy = Math.max(0, i.wantCount - i.haveCount);
+                            qtyNum.textContent = toBuy;
+                        }
                     }
-                }
-            });
+                });
+            }
 
             return;
         }
@@ -2213,7 +2218,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                 sectionItems = [];
                 groupedMap.forEach(group => {
                     if (nameToSection.get(group.text) === section.id) {
-                        sectionItems.push(group);
+                        // In shop mode, hide items with 0 quantity to buy unless editing
+                        const toBuy = Math.max(0, group.wantCount - group.haveCount);
+                        if (editMode || toBuy > 0) {
+                            sectionItems.push(group);
+                        }
                     }
                 });
 

--- a/tests/hide_zero_qty_shop.spec.js
+++ b/tests/hide_zero_qty_shop.spec.js
@@ -1,0 +1,87 @@
+const { mockFirebase, setMockState } = require('./mockFirebase');
+const { test, expect } = require('@playwright/test');
+
+test('hide 0 quantity to buy items in shop mode when not editing', async ({ page }) => {
+    const initialState = {
+        lists: [{
+            id: 'list-1',
+            name: 'Grocery List',
+            theme: 'var(--theme-blue)',
+            accent: 'var(--theme-amber)',
+            homeSections: [{ id: 'sec-h-def', name: 'Home' }],
+            shopSections: [{ id: 'sec-s-def', name: 'Uncategorized' }],
+            items: [
+                {
+                    id: 'item-1',
+                    text: 'Item A (1 to buy)',
+                    wantCount: 1,
+                    haveCount: 0,
+                    shopCompleted: false,
+                    homeSectionId: 'sec-h-def',
+                    shopSectionId: 'sec-s-def',
+                    homeIndex: 0,
+                    shopIndex: 0
+                },
+                {
+                    id: 'item-2',
+                    text: 'Item B (0 to buy)',
+                    wantCount: 0,
+                    haveCount: 0,
+                    shopCompleted: true,
+                    homeSectionId: 'sec-h-def',
+                    shopSectionId: 'sec-s-def',
+                    homeIndex: 1,
+                    shopIndex: 1
+                },
+                {
+                    id: 'item-3',
+                    text: 'Item C (Completed)',
+                    wantCount: 1,
+                    haveCount: 1,
+                    shopCompleted: true,
+                    homeSectionId: 'sec-h-def',
+                    shopSectionId: 'sec-s-def',
+                    homeIndex: 2,
+                    shopIndex: 2
+                }
+            ]
+        }],
+        currentListId: 'list-1',
+        mode: 'shop',
+        editMode: false
+    };
+
+    await mockFirebase(page, initialState);
+    await page.addInitScript(() => { localStorage.setItem('grocery-logged-in', 'true'); });
+    await page.goto('http://localhost:3000');
+
+    // Wait for the app to load
+    await page.waitForSelector('.app-container:not(.hidden)');
+
+    // Verify we are in shop mode and NOT in edit mode
+    await expect(page.locator('.app-container')).toHaveClass(/shop-mode/);
+    await expect(page.locator('.app-container')).toHaveClass(/hide-drag-handles/);
+
+    // Only Item A should be visible
+    await expect(page.locator('.item-text', { hasText: 'Item A (1 to buy)' })).toBeVisible();
+    await expect(page.locator('.item-text', { hasText: 'Item B (0 to buy)' })).not.toBeVisible();
+    await expect(page.locator('.item-text', { hasText: 'Item C (Completed)' })).not.toBeVisible();
+
+    // Toggle edit mode ON
+    await page.click('#toolbar-reorder');
+    await expect(page.locator('.app-container')).not.toHaveClass(/hide-drag-handles/);
+
+    // All items should be visible
+    await expect(page.locator('.item-text', { hasText: 'Item A (1 to buy)' })).toBeVisible();
+    await expect(page.locator('.item-text', { hasText: 'Item B (0 to buy)' })).toBeVisible();
+    await expect(page.locator('.item-text', { hasText: 'Item C (Completed)' })).toBeVisible();
+
+    // Toggle edit mode OFF again
+    await page.click('#toolbar-reorder');
+    await expect(page.locator('.app-container')).toHaveClass(/hide-drag-handles/);
+
+    // Only Item A should be visible again
+    await expect(page.locator('.item-text', { hasText: 'Item A (1 to buy)' })).toBeVisible();
+    await expect(page.locator('.item-text', { hasText: 'Item B (0 to buy)' })).not.toBeVisible();
+    await expect(page.locator('.item-text', { hasText: 'Item C (Completed)' })).not.toBeVisible();
+});


### PR DESCRIPTION
I have implemented the requested feature to hide items with 0 quantity to buy in Store Mode unless the user is in Edit Mode.

Key implementation details:
1. **Filtering logic**: In the `renderList` function, I added a check for the quantity to buy (`wantCount - haveCount`). If this value is 0 or less, and we are in Store Mode without Edit Mode active, the item group is skipped during rendering.
2. **UI Reactivity**:
   - I ensured that the `renderList()` function is called when the user toggles Edit Mode. Previously, only the toolbar UI was updated, but the list content remained the same until another state change occurred.
   - I updated `setWant()` to trigger a full re-render when the user is in the "Store Mode" (non-edit) view. This ensures that if a user manually sets an item's want quantity to 0 via the stepper, the item disappears immediately.
3. **Testing**: 
   - A new test file `tests/hide_zero_qty_shop.spec.js` was added to specifically cover this requirement.
   - I also fixed a regression in `tests/exit_edit_mode.test.js` where the test was missing the standard setup logic required to run against the local development server.

These changes provide a cleaner shopping experience by focusing only on items that actually need to be purchased, while still allowing full visibility and management during editing.

Fixes #355

---
*PR created automatically by Jules for task [5494265711418131701](https://jules.google.com/task/5494265711418131701) started by @camyoung1234*